### PR TITLE
Change search distance fields to f32

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -93,9 +93,9 @@ impl fmt::Display for ResultType {
 ///Represents a radius around a given location to return search results for.
 pub enum Distance {
     ///A radius given in miles.
-    Miles(u32),
+    Miles(f32),
     ///A radius given in kilometers.
-    Kilometers(u32),
+    Kilometers(f32),
 }
 
 ///Represents a tweet search query before being sent.


### PR DESCRIPTION
Even though official Twitter api documentation says it supports other
units than kilometer, tests shows using kilometer with floating point
numbers gives better results.