### PR TITLE
Make `max_id` and `since_id` fields public in SearchResults

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ travis-ci = { repository = "QuietMisdreavus/twitter-rs" }
 appveyor = { repository = "QuietMisdreavus/twitter-rs" }
 
 [dependencies]
-hyper = "0.10.9"
+hyper = "0.10.13"
 hyper-native-tls = "0.2.4"
 native-tls = "0.1.4"
 url = "1.5.1"

--- a/src/search.rs
+++ b/src/search.rs
@@ -93,9 +93,9 @@ impl fmt::Display for ResultType {
 ///Represents a radius around a given location to return search results for.
 pub enum Distance {
     ///A radius given in miles.
-    Miles(u32),
+    Miles(f32),
     ///A radius given in kilometers.
-    Kilometers(u32),
+    Kilometers(f32),
 }
 
 ///Represents a tweet search query before being sent.

--- a/src/search.rs
+++ b/src/search.rs
@@ -229,8 +229,10 @@ pub struct SearchResult<'a> {
     ///The query used to generate this page of results. Note that changing this will not affect the
     ///`next_page` method.
     pub query: String,
-    max_id: u64,
-    since_id: u64,
+    ///Last tweet id in this page of results. This id can be used in `SearchBuilder::since_tweet`
+    pub max_id: u64,
+    ///First tweet id in this page of results. This id can be used in `SearchBuilder::since_tweet`
+    pub since_id: u64,
     params: Option<ParamList<'a>>,
 }
 


### PR DESCRIPTION
This change makes possible saving `SearchResults::max_id` for later use in
`SearchBuilder::since_tweet` by making `SearchResults::max_id` and 
`SearchResults::since_id` public.

PS: there is another pull request which includes `Change search distance fields to f32` please ignore that in this PR. Sorry about that.