### PR TITLE
Fix improper lifetime on SearchResult methods

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -254,7 +254,7 @@ impl<'a> FromJson for SearchResult<'a> {
 
 impl<'a> SearchResult<'a> {
     ///Load the next page of search results for the same query.
-    pub fn older(&self, token: &auth::Token) -> WebResponse<SearchResult> {
+    pub fn older(&self, token: &auth::Token) -> WebResponse<SearchResult<'a>> {
         let mut params = self.params.as_ref().cloned().unwrap_or_default();
         params.remove("since_id");
 
@@ -273,7 +273,7 @@ impl<'a> SearchResult<'a> {
     }
 
     ///Load the previous page of search results for the same query.
-    pub fn newer(&self, token: &auth::Token) -> WebResponse<SearchResult> {
+    pub fn newer(&self, token: &auth::Token) -> WebResponse<SearchResult<'a>> {
         let mut params = self.params.as_ref().cloned().unwrap_or_default();
         params.remove("max_id");
 


### PR DESCRIPTION
Return value does not borrow anything from the old SearchResult value (as signatures without explicit lifetimes indicate due to lifetime elision rules), they just happen to have a copy of a reference stored
inside - and can have the same lifetime parameter as the original SearchResult value.

This would make code like this compile:

```rust
let mut result = search::search("foo").call(&token).unwrap();
loop {
  // do something with result
  // and load more
  result = result.older().unwrap();
}
```