### PR TITLE
Make 'twitter::auth' public to expose 'twitter::auth::get' / 'twitter::auth::post'

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@ extern crate regex;
 extern crate unicode_normalization;
 
 #[macro_use] mod common;
-mod auth;
+pub mod auth;
 pub mod error;
 pub mod user;
 pub mod entities;


### PR DESCRIPTION
I'm using the new `/direct_message/events/list` API from Twitter. I started to work on adding this in to `egg-mode` and I'm at a loss of how to work it in. It's a cursored collection but the cursor is in different format (string instead of integer) than other collections in Twitter.

This small change would allow me to take advantage of the underlying request/auth setup and parse the response myself until this library supports the events API.