### PR TITLE
Add direct message events API to TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -61,6 +61,9 @@ return a list of IDs of something are grouped in with the rest of the main struc
 - [x] direct\_messages/show (`direct::show`)
 - [x] direct\_messages/new (`direct::send`)
 - [x] direct\_messages/destroy (`direct::delete`)
+- [ ] direct\_messages/events/list
+- [ ] direct\_messages/events/show
+- [ ] direct\_messages/events/new
 
 ### Users
 


### PR DESCRIPTION
From what it sounds like these are intended to replace the existing direct message APIs at some point.

The new creation API supports sending message attachments which is neat.

The new list API returns 30 days back of message (instead of 200 max) and both send/received in one API call.