### PR TITLE
fix(media): Add alt text support for accessibility

### DIFF
--- a/sample_payloads/sample-image-alt-text.json
+++ b/sample_payloads/sample-image-alt-text.json
@@ -1,0 +1,187 @@
+{
+    "created_at": "Sat Jan 05 15:57:43 +0000 2019",
+    "id": 1081580512102268928,
+    "id_str": "1081580512102268928",
+    "full_text": "test image with al text https:\/\/t.co\/UpTnzyDABM",
+    "truncated": false,
+    "display_text_range": [
+        0,
+        23
+    ],
+    "entities": {
+        "hashtags": [],
+        "symbols": [],
+        "user_mentions": [],
+        "urls": [],
+        "media": [
+            {
+                "id": 1081580400462520320,
+                "id_str": "1081580400462520320",
+                "indices": [
+                    24,
+                    47
+                ],
+                "media_url": "http:\/\/pbs.twimg.com\/media\/DwKLpM2X4AAjDNG.jpg",
+                "media_url_https": "https:\/\/pbs.twimg.com\/media\/DwKLpM2X4AAjDNG.jpg",
+                "url": "https:\/\/t.co\/UpTnzyDABM",
+                "display_url": "pic.twitter.com\/UpTnzyDABM",
+                "expanded_url": "https:\/\/twitter.com\/_klausi_\/status\/1081580512102268928\/photo\/1",
+                "type": "photo",
+                "sizes": {
+                    "medium": {
+                        "w": 1200,
+                        "h": 917,
+                        "resize": "fit"
+                    },
+                    "thumb": {
+                        "w": 150,
+                        "h": 150,
+                        "resize": "crop"
+                    },
+                    "small": {
+                        "w": 680,
+                        "h": 519,
+                        "resize": "fit"
+                    },
+                    "large": {
+                        "w": 1300,
+                        "h": 993,
+                        "resize": "fit"
+                    }
+                }
+            }
+        ]
+    },
+    "extended_entities": {
+        "media": [
+            {
+                "id": 1081580400462520320,
+                "id_str": "1081580400462520320",
+                "indices": [
+                    24,
+                    47
+                ],
+                "media_url": "http:\/\/pbs.twimg.com\/media\/DwKLpM2X4AAjDNG.jpg",
+                "media_url_https": "https:\/\/pbs.twimg.com\/media\/DwKLpM2X4AAjDNG.jpg",
+                "url": "https:\/\/t.co\/UpTnzyDABM",
+                "display_url": "pic.twitter.com\/UpTnzyDABM",
+                "expanded_url": "https:\/\/twitter.com\/_klausi_\/status\/1081580512102268928\/photo\/1",
+                "type": "photo",
+                "sizes": {
+                    "medium": {
+                        "w": 1200,
+                        "h": 917,
+                        "resize": "fit"
+                    },
+                    "thumb": {
+                        "w": 150,
+                        "h": 150,
+                        "resize": "crop"
+                    },
+                    "small": {
+                        "w": 680,
+                        "h": 519,
+                        "resize": "fit"
+                    },
+                    "large": {
+                        "w": 1300,
+                        "h": 993,
+                        "resize": "fit"
+                    }
+                },
+                "ext_alt_text": "test alt text for the image"
+            }
+        ]
+    },
+    "source": "\u003ca href=\"http:\/\/twitter.com\" rel=\"nofollow\"\u003eTwitter Web Client\u003c\/a\u003e",
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+        "id": 71885183,
+        "id_str": "71885183",
+        "name": "klausi\ud83d\udca7\ud83e\udd80",
+        "screen_name": "_klausi_",
+        "location": "Vienna",
+        "description": "Building @jobiqo. Interested in tech, politics, gender studies, infosec, #rustlang, #drupal. He\/his. https:\/\/t.co\/J3HG33Slx1",
+        "url": "https:\/\/t.co\/DElQOTCPMY",
+        "entities": {
+            "url": {
+                "urls": [
+                    {
+                        "url": "https:\/\/t.co\/DElQOTCPMY",
+                        "expanded_url": "https:\/\/klau.si",
+                        "display_url": "klau.si",
+                        "indices": [
+                            0,
+                            23
+                        ]
+                    }
+                ]
+            },
+            "description": {
+                "urls": [
+                    {
+                        "url": "https:\/\/t.co\/J3HG33Slx1",
+                        "expanded_url": "http:\/\/mastodon.social\/@klausi",
+                        "display_url": "mastodon.social\/@klausi",
+                        "indices": [
+                            101,
+                            124
+                        ]
+                    }
+                ]
+            }
+        },
+        "protected": false,
+        "followers_count": 1474,
+        "friends_count": 804,
+        "listed_count": 111,
+        "created_at": "Sat Sep 05 20:31:49 +0000 2009",
+        "favourites_count": 523,
+        "utc_offset": null,
+        "time_zone": null,
+        "geo_enabled": false,
+        "verified": false,
+        "statuses_count": 196,
+        "lang": "en",
+        "contributors_enabled": false,
+        "is_translator": false,
+        "is_translation_enabled": false,
+        "profile_background_color": "C0DEED",
+        "profile_background_image_url": "http:\/\/abs.twimg.com\/images\/themes\/theme1\/bg.png",
+        "profile_background_image_url_https": "https:\/\/abs.twimg.com\/images\/themes\/theme1\/bg.png",
+        "profile_background_tile": false,
+        "profile_image_url": "http:\/\/pbs.twimg.com\/profile_images\/954677261164339202\/mgEXqhs6_normal.jpg",
+        "profile_image_url_https": "https:\/\/pbs.twimg.com\/profile_images\/954677261164339202\/mgEXqhs6_normal.jpg",
+        "profile_banner_url": "https:\/\/pbs.twimg.com\/profile_banners\/71885183\/1529859862",
+        "profile_image_extensions_alt_text": null,
+        "profile_banner_extensions_alt_text": null,
+        "profile_link_color": "142DCF",
+        "profile_sidebar_border_color": "C0DEED",
+        "profile_sidebar_fill_color": "DDEEF6",
+        "profile_text_color": "333333",
+        "profile_use_background_image": true,
+        "has_extended_profile": true,
+        "default_profile": false,
+        "default_profile_image": false,
+        "following": null,
+        "follow_request_sent": null,
+        "notifications": null,
+        "translator_type": "none"
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "is_quote_status": false,
+    "retweet_count": 0,
+    "favorite_count": 1,
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "possibly_sensitive_appealable": false,
+    "lang": "en"
+}

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -106,6 +106,9 @@ pub struct MediaEntity {
     ///For media entities corresponding to videos, this contains extra information about the linked
     ///video.
     pub video_info: Option<VideoInfo>,
+    ///Alt text for accessibility. If alt text isn't available for a given image, this will be
+    ///`None`.
+    pub ext_alt_text: Option<String>,
 }
 
 ///Represents the types of media that can be attached to a tweet.

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -106,8 +106,7 @@ pub struct MediaEntity {
     ///For media entities corresponding to videos, this contains extra information about the linked
     ///video.
     pub video_info: Option<VideoInfo>,
-    ///Alt text for accessibility. If alt text isn't available for a given image, this will be
-    ///`None`.
+    ///Media alt text, if present.
     pub ext_alt_text: Option<String>,
 }
 

--- a/src/tweet/fun.rs
+++ b/src/tweet/fun.rs
@@ -21,6 +21,7 @@ pub fn show(id: u64, token: &auth::Token)
     add_param(&mut params, "id", id.to_string());
     add_param(&mut params, "include_my_retweet", "true");
     add_param(&mut params, "tweet_mode", "extended");
+    add_param(&mut params, "include_ext_alt_text", "true");
 
     let req = auth::get(links::statuses::SHOW, token, Some(&params));
 
@@ -79,6 +80,7 @@ pub fn lookup<I: IntoIterator<Item=u64>>(ids: I, token: &auth::Token)
     });
     add_param(&mut params, "id", id_param);
     add_param(&mut params, "tweet_mode", "extended");
+    add_param(&mut params, "include_ext_alt_text", "true");
 
     let req = auth::post(links::statuses::LOOKUP, token, Some(&params));
 
@@ -104,6 +106,7 @@ pub fn lookup_map<I: IntoIterator<Item=u64>>(ids: I, token: &auth::Token)
     add_param(&mut params, "id", id_param);
     add_param(&mut params, "map", "true");
     add_param(&mut params, "tweet_mode", "extended");
+    add_param(&mut params, "include_ext_alt_text", "true");
 
     let req = auth::post(links::statuses::LOOKUP, token, Some(&params));
 

--- a/src/tweet/mod.rs
+++ b/src/tweet/mod.rs
@@ -549,6 +549,7 @@ impl<'a> Timeline<'a> {
         let mut params = self.params_base.as_ref().cloned().unwrap_or_default();
         add_param(&mut params, "count", self.count.to_string());
         add_param(&mut params, "tweet_mode", "extended");
+        add_param(&mut params, "include_ext_alt_text", "true");
 
         if let Some(id) = since_id {
             add_param(&mut params, "since_id", id.to_string());

--- a/src/tweet/mod.rs
+++ b/src/tweet/mod.rs
@@ -985,4 +985,12 @@ mod tests {
                    "it's working: follow @andrewhuangbot for a random lyric of mine every hour. we'll call this version 0.1.0. wanna get line breaks in there");
     }
 
+    #[test]
+    fn parse_image_alt_text() {
+        let sample = load_tweet("sample_payloads/sample-image-alt-text.json");
+        let extended_entities = sample.extended_entities.unwrap();
+
+        assert_eq!(extended_entities.media[0].ext_alt_text, Some("test alt text for the image".to_string()));
+    }
+
 }


### PR DESCRIPTION
See https://blog.twitter.com/developer/en_us/a/2016/alt-text-support-for-twitter-cards-and-the-rest-api.html

Not sure why the Twitter docs don't mention the ext_alt_text field at https://developer.twitter.com/en/docs/tweets/data-dictionary/overview/entities-object#media , maybe they forgot to document it there?

I have not looked into test coverage yet.