### PR TITLE
Add support for hyper-rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ appveyor = { repository = "QuietMisdreavus/twitter-rs" }
 [dependencies]
 hyper = "0.12.13"
 hyper-tls = "0.3.1"
-native-tls = "0.2.2"
+hyper-rustls = { version = "0.15.0", optional = true }
+native-tls = { version = "0.2.2", optional = true }
 futures = "0.1.14"
 tokio = "0.1.11"
 url = "1.5.1"
@@ -32,3 +33,6 @@ serde = "1.0.27"
 serde_json = "1.0.9"
 serde_derive = "1.0.27"
 base64 = "0.9.0"
+
+[features]
+default = ["native-tls"]

--- a/src/common/response.rs
+++ b/src/common/response.rs
@@ -11,7 +11,10 @@ use std::ops::{Deref, DerefMut};
 use hyper::client::ResponseFuture;
 use hyper::{self, Body, StatusCode, Request};
 use hyper::header::CONTENT_LENGTH;
+#[cfg(feature = "native-tls")]
 use hyper_tls::HttpsConnector;
+#[cfg(feature = "hyper-rustls")]
+use hyper_rustls::HttpsConnector;
 use futures::{Async, Future, Poll, Stream};
 use error::{self, TwitterErrors};
 use error::Error::*;
@@ -359,7 +362,10 @@ impl<T> FromIterator<Response<T>> for Response<Vec<T>> {
 
 pub fn get_response(request: Request<Body>) -> Result<ResponseFuture, error::Error> {
     // TODO: num-cpus?
+    #[cfg(feature = "native-tls")]
     let connector = try!(HttpsConnector::new(1));
+    #[cfg(feature = "hyper-rustls")]
+    let connector = HttpsConnector::new(1);
     let client = hyper::Client::builder().build(connector);
     Ok(client.request(request))
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,7 @@
 
 use std::{self, fmt};
 use hyper;
+#[cfg(feature = "native-tls")]
 use native_tls;
 use chrono;
 use serde_json;
@@ -117,6 +118,7 @@ pub enum Error {
     NetError(hyper::error::Error),
     ///The `native_tls` implementation returned an error. The enclosed error was returned from
     ///`native_tls`.
+    #[cfg(feature = "native-tls")]
     TlsError(native_tls::Error),
     ///An error was experienced while processing the response stream. The enclosed error was
     ///returned from libstd.
@@ -156,6 +158,7 @@ impl std::fmt::Display for Error {
             Error::MediaError(ref err) => write!(f, "Error processing media: {}", err.message),
             Error::BadStatus(ref val) => write!(f, "Error status received: {}", val),
             Error::NetError(ref err) => write!(f, "Network error: {}", err),
+            #[cfg(feature = "native-tls")]
             Error::TlsError(ref err) => write!(f, "TLS error: {}", err),
             Error::IOError(ref err) => write!(f, "IO error: {}", err),
             Error::DeserializeError(ref err) => write!(f, "JSON deserialize error: {}", err),
@@ -179,6 +182,7 @@ impl std::error::Error for Error {
             Error::MediaError(_) => "Error processing media",
             Error::BadStatus(_) => "Response included error code",
             Error::NetError(ref err) => err.description(),
+            #[cfg(feature = "native-tls")]
             Error::TlsError(ref err) => err.description(),
             Error::IOError(ref err) => err.description(),
             Error::DeserializeError(ref err) => err.description(),
@@ -192,6 +196,7 @@ impl std::error::Error for Error {
     fn cause(&self) -> Option<&std::error::Error> {
         match *self {
             Error::NetError(ref err) => Some(err),
+            #[cfg(feature = "native-tls")]
             Error::TlsError(ref err) => Some(err),
             Error::IOError(ref err) => Some(err),
             Error::TimestampParseError(ref err) => Some(err),
@@ -210,6 +215,7 @@ impl From<hyper::error::Error> for Error {
     }
 }
 
+#[cfg(feature = "native-tls")]
 impl From<native_tls::Error> for Error {
     fn from(err: native_tls::Error) -> Error {
         Error::TlsError(err)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,8 +155,12 @@ extern crate hyper;
 #[macro_use] extern crate lazy_static;
 extern crate futures;
 extern crate tokio;
+#[cfg(feature = "native-tls")]
 extern crate hyper_tls;
+#[cfg(feature = "native-tls")]
 extern crate native_tls;
+#[cfg(feature = "hyper-rustls")]
+extern crate hyper_rustls;
 extern crate url;
 extern crate rand;
 extern crate hmac;


### PR DESCRIPTION
This PR adds a cargo feature that allows `native-tls` to be replaced with `hyper-rustls`, which describes itself as, "a pure-Rust HTTPS connector for hyper, based on Rustls". This allows `egg-mode` to be used without a transient dependency on openssl where that is what `native-tls` would choose, for example on FreeBSD and Linux. With `hyper-rustls` enabled this also makes egg-mode easier to cross compile as a cross-compiled version of openssl need not be made available.

The feature is used by adding `egg-mode` to a `Cargo.toml` like this (assuming this change has been merged and published into a theoretical version 0.12.1):

```
egg-mode = { version = "0.12.1", default-features = false, features = ["hyper-rustls"] }
```

Some tweaks the CI setup should probably be done to run tests with the new feature as well. I can have a go at that if you like.