### PR TITLE
fix(entities): Expanded URLs are sometimes null, represent them as Option

### DIFF
--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -158,7 +158,9 @@ pub fn print_tweet(tweet: &egg_mode::tweet::Tweet) {
     if !tweet.entities.urls.is_empty() {
         println!("URLs contained in the tweet:");
         for url in &tweet.entities.urls {
-            println!("{}", url.expanded_url);
+            if let Some(expanded_url) = &url.expanded_url {
+                println!("{}", expanded_url);
+            }
         }
     }
 

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -192,7 +192,7 @@ pub struct UrlEntity {
     ///
     ///Meant to be used as hover-text when a user mouses over a link.
     #[serde(default)]
-    pub expanded_url: String,
+    pub expanded_url: Option<String>,
     ///The byte offsets in the companion text where the URL was extracted from.
     #[serde(rename = "indices")]
     pub range: (usize, usize),


### PR DESCRIPTION
Fixes #51 