### PR TITLE
Make lang optional on tweet and user

### DIFF
--- a/src/tweet/mod.rs
+++ b/src/tweet/mod.rs
@@ -188,7 +188,7 @@ pub struct Tweet {
     pub in_reply_to_status_id: Option<u64>,
     ///Can contain a language ID indicating the machine-detected language of the text, or "und" if
     ///no language could be detected.
-    pub lang: String,
+    pub lang: Option<String>,
     ///When present, the `Place` that this tweet is associated with (but not necessarily where it
     ///originated from).
     pub place: Option<place::Place>,

--- a/src/tweet/raw.rs
+++ b/src/tweet/raw.rs
@@ -24,7 +24,7 @@ pub(crate) struct RawTweet {
     pub in_reply_to_user_id: Option<u64>,
     pub in_reply_to_screen_name: Option<String>,
     pub in_reply_to_status_id: Option<u64>,
-    pub lang: String,
+    pub lang: Option<String>,
     pub place: Option<place::Place>,
     pub possibly_sensitive: Option<bool>,
     pub quoted_status_id: Option<u64>,

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -233,7 +233,7 @@ pub struct TwitterUser {
     /// interface language, not necessarily the content of their Tweets.
     ///
     /// [BCP 47]: https://tools.ietf.org/html/bcp47
-    pub lang: String,
+    pub lang: Option<String>,
     /// The number of public lists the user is a member of.
     pub listed_count: i32,
     /// The user-entered location field from their profile. Not necessarily parseable

--- a/src/user/raw.rs
+++ b/src/user/raw.rs
@@ -58,7 +58,7 @@ pub struct RawTwitterUser {
     /// interface language, not necessarily the content of their Tweets.
     ///
     /// [BCP 47]: https://tools.ietf.org/html/bcp47
-    pub lang: String,
+    pub lang: Option<String>,
     /// The number of public lists the user is a member of.
     pub listed_count: i32,
     /// The user-entered location field from their profile. Not necessarily parseable


### PR DESCRIPTION
It seems Twitter have started serving up `null` for `lang` on tweets and users. This was a quick change to get [read-rust](https://github.com/wezm/read-rust) working again.