### PR TITLE
Simplify futures implementations

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ matrix:
 
 cache:
   - '%USERPROFILE%\.cargo -> Cargo.toml'
-  - '%USERPROFILE%\.rustup'
+  - '%USERPROFILE%\.rustup -> appveyor.yml'
 
 install:
   - curl -sSf -o rustup-init.exe https://win.rustup.rs/

--- a/src/direct/fun.rs
+++ b/src/direct/fun.rs
@@ -11,7 +11,10 @@ use crate::{auth, links};
 use super::*;
 
 ///Lookup a single DM by its numeric ID.
-pub fn show(id: u64, token: &auth::Token) -> FutureResponse<DirectMessage> {
+pub fn show(
+    id: u64,
+    token: &auth::Token,
+) -> impl Future<Item = Response<DirectMessage>, Error = error::Error> {
     let mut params = HashMap::new();
     add_param(&mut params, "id", id.to_string());
 
@@ -43,7 +46,7 @@ pub fn send<'id, T: Into<UserID<'id>>>(
     to: T,
     text: &str,
     token: &auth::Token,
-) -> FutureResponse<DirectMessage> {
+) -> impl Future<Item = Response<DirectMessage>, Error = error::Error> {
     let mut params = HashMap::new();
     add_name_param(&mut params, &to.into());
 
@@ -60,7 +63,10 @@ pub fn send<'id, T: Into<UserID<'id>>>(
 ///
 ///On a successful deletion, the future returned by this function yields the freshly-deleted
 ///message.
-pub fn delete(id: u64, token: &auth::Token) -> FutureResponse<DirectMessage> {
+pub fn delete(
+    id: u64,
+    token: &auth::Token,
+) -> impl Future<Item = Response<DirectMessage>, Error = error::Error> {
     let mut params = HashMap::new();
     add_param(&mut params, "id", id.to_string());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,7 +170,7 @@ pub mod user;
 
 pub use crate::auth::{
     access_token, authenticate_url, authorize_url, bearer_token, invalidate_bearer, request_token,
-    verify_tokens, AuthFuture, KeyPair, Token,
+    verify_tokens, KeyPair, Token,
 };
 pub use crate::common::{
     FutureResponse, Response, ResponseIter, ResponseIterMut, ResponseIterRef, TwitterFuture,

--- a/src/search.rs
+++ b/src/search.rs
@@ -4,7 +4,7 @@
 
 //! Structs and methods for searching for tweets.
 //!
-//! Since there are several optiona parameters for searches, egg-mode handles it with a builder
+//! Since there are several optional parameters for searches, egg-mode handles it with a builder
 //! pattern. To begin, call `search` with your requested search term. Additional parameters can be
 //! added onto the `SearchBuilder` struct that is returned. When you're ready to load the first
 //! page of results, hand your tokens to `call`.


### PR DESCRIPTION
I found some of the `Future` implementations hard to read. This replaces them with combinators, where feasible.

`TwitterFuture` and `RawFuture` are more involved (I quickly ran into lifetime issues) so are deferred for now.
