### PR TITLE
Make hyper-tls optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ futures = "0.1.27"
 hmac = "0.7.0"
 hyper = "0.12.29"
 hyper-rustls = { version = "0.16.1", optional = true }
-hyper-tls = "0.3.2"
+hyper-tls = { version = "0.3.2", optional = true }
 lazy_static = "1.3.0"
 native-tls = { version = "0.2.3", optional = true }
 mime = "0.3.13"
@@ -35,7 +35,8 @@ tokio = "0.1.21"
 url = "1.7.2"
 
 [features]
-default = ["native-tls"]
+default = ["native_tls"]
+native_tls = ["native-tls", "hyper-tls"]
 
 [dev-dependencies]
 yansi = "0.5.0"

--- a/src/common/response.rs
+++ b/src/common/response.rs
@@ -13,7 +13,7 @@ use hyper::header::CONTENT_LENGTH;
 use hyper::{self, Body, Request, StatusCode};
 #[cfg(feature = "hyper-rustls")]
 use hyper_rustls::HttpsConnector;
-#[cfg(feature = "native-tls")]
+#[cfg(feature = "native_tls")]
 use hyper_tls::HttpsConnector;
 use serde::Deserialize;
 use serde_json;
@@ -393,7 +393,7 @@ impl<T> FromIterator<Response<T>> for Response<Vec<T>> {
 
 pub fn get_response(request: Request<Body>) -> Result<ResponseFuture, error::Error> {
     // TODO: num-cpus?
-    #[cfg(feature = "native-tls")]
+    #[cfg(feature = "native_tls")]
     let connector = HttpsConnector::new(1)?;
     #[cfg(feature = "hyper-rustls")]
     let connector = HttpsConnector::new(1);

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,7 +17,7 @@
 
 use chrono;
 use hyper;
-#[cfg(feature = "native-tls")]
+#[cfg(feature = "native_tls")]
 use native_tls;
 use serde::{Deserialize, Serialize};
 use serde_json;
@@ -122,7 +122,7 @@ pub enum Error {
     NetError(hyper::error::Error),
     ///The `native_tls` implementation returned an error. The enclosed error was returned from
     ///`native_tls`.
-    #[cfg(feature = "native-tls")]
+    #[cfg(feature = "native_tls")]
     TlsError(native_tls::Error),
     ///An error was experienced while processing the response stream. The enclosed error was
     ///returned from libstd.
@@ -164,7 +164,7 @@ impl std::fmt::Display for Error {
             Error::MediaError(ref err) => write!(f, "Error processing media: {}", err.message),
             Error::BadStatus(ref val) => write!(f, "Error status received: {}", val),
             Error::NetError(ref err) => write!(f, "Network error: {}", err),
-            #[cfg(feature = "native-tls")]
+            #[cfg(feature = "native_tls")]
             Error::TlsError(ref err) => write!(f, "TLS error: {}", err),
             Error::IOError(ref err) => write!(f, "IO error: {}", err),
             Error::DeserializeError(ref err) => write!(f, "JSON deserialize error: {}", err),
@@ -188,7 +188,7 @@ impl std::error::Error for Error {
             Error::MediaError(_) => "Error processing media",
             Error::BadStatus(_) => "Response included error code",
             Error::NetError(ref err) => err.description(),
-            #[cfg(feature = "native-tls")]
+            #[cfg(feature = "native_tls")]
             Error::TlsError(ref err) => err.description(),
             Error::IOError(ref err) => err.description(),
             Error::DeserializeError(ref err) => err.description(),
@@ -202,7 +202,7 @@ impl std::error::Error for Error {
     fn cause(&self) -> Option<&dyn std::error::Error> {
         match *self {
             Error::NetError(ref err) => Some(err),
-            #[cfg(feature = "native-tls")]
+            #[cfg(feature = "native_tls")]
             Error::TlsError(ref err) => Some(err),
             Error::IOError(ref err) => Some(err),
             Error::TimestampParseError(ref err) => Some(err),
@@ -221,7 +221,7 @@ impl From<hyper::error::Error> for Error {
     }
 }
 
-#[cfg(feature = "native-tls")]
+#[cfg(feature = "native_tls")]
 impl From<native_tls::Error> for Error {
     fn from(err: native_tls::Error) -> Error {
         Error::TlsError(err)


### PR DESCRIPTION
This makes `hyper-tls` optional by introducing custom feature which is a bit incompatible as originally it used only `native-tls` to determine which TLS library to use, but that left `hyper-tls` to be dependency even if user would need only `rustls`