### PR TITLE
TweetSource optional

### DIFF
--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -146,7 +146,9 @@ pub fn print_tweet(tweet: &egg_mode::tweet::Tweet) {
         println!("{}", Paint::green(&tweet.text));
     }
 
-    println!("➜ via {} ({})", tweet.source.name, tweet.source.url);
+    if let Some(source) = &tweet.source {
+        println!("➜ via {} ({})", source.name, source.url);
+    }
 
     if let Some(ref place) = tweet.place {
         println!("➜ from: {}", place.full_name);

--- a/src/tweet/raw.rs
+++ b/src/tweet/raw.rs
@@ -33,7 +33,7 @@ pub(crate) struct RawTweet {
     pub retweeted: Option<bool>,
     pub retweeted_status: Option<Box<Tweet>>,
     #[serde(deserialize_with = "deserialize_tweet_source")]
-    pub source: TweetSource,
+    pub source: Option<TweetSource>,
     pub text: Option<String>,
     pub full_text: Option<String>,
     pub truncated: bool,


### PR DESCRIPTION
I encountered

```
DeserializeError(Error("Invalid response received: TweetSource had no link href (Some(\"\"))", line: 1, column: 339751))
```

when fetching users via `friends_of`, `followers_of`. 

The source attribute in tweets (that get pulled in via status tweets) can be empty instead of an `a` tag. In this case I think that parsing shouldn't fail. I think making the `TweetSource` optional would be a proper fix.