### PR TITLE
Prepare for 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egg-mode"
-version = "0.14.0"
+version = "0.14.0-beta.1"
 authors = ["QuietMisdreavus <grey@quietmisdreavus.net>", "Alex Whitney <adwhit@fastmail.com>"]
 description = "Library to interact with the Twitter API"
 documentation = "https://tonberry.quietmisdreavus.net/doc/egg_mode/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ regex = "1.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha-1 = "0.8"
+thiserror = "1.0.11"
 tokio = { version = "0.2.8", features = ["time", "rt-core", "macros"] }
 url = "2.1.1"
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Twitter library for Rust ![Build Status](https://github.com/QuietMisdreavus/twitter-rs/workflows/CI/badge.svg)
 
-[v0.14.0 Documentation](https://tonberry.quietmisdreavus.net/doc/egg_mode/)
+[Documentation](https://docs.rs/egg-mode/)
 
 This is a library for interacting with Twitter from Rust. You can see how much of the Public API is
 available in the file [TODO.md]. In addition to eventually implementing the entire Public API, an
@@ -26,14 +26,14 @@ To start using this library, put the following into your Cargo.toml:
 
 ```TOML
 [dependencies]
-egg-mode = "0.14.0"
+egg-mode = "0.14.0-beta.1"
 ```
 
 By default, `egg-mode` uses `native-tls` for encryption, but also supports `rustls`.
 This may be helpful if you wish to avoid linking against `OpenSSL`.
 To enable, modify your `Cargo.toml` entry:
 ```
-egg-mode = { version = "0.14", features = ["hyper-rustls"], default-features = false }
+egg-mode = { version = "0.14-beta.1", features = ["hyper-rustls"], default-features = false }
 ```
 
 See available methods and tips to get started in the [Documentation][].

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -22,7 +22,7 @@ async fn main() {
     users.push(config.user_id.into());
     users.push("SwiftOnSecurity".into());
 
-    for user in user::lookup(&users, &config.token)
+    for user in user::lookup(users, &config.token)
         .await
         .unwrap()
         .response

--- a/examples/bearer.rs
+++ b/examples/bearer.rs
@@ -4,23 +4,26 @@
 
 mod common;
 
+use egg_mode::error::Result;
+
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<()> {
     let con_key = include_str!("common/consumer_key").trim();
     let con_secret = include_str!("common/consumer_secret").trim();
 
     let con_token = egg_mode::KeyPair::new(con_key, con_secret);
 
     println!("Pulling up the bearer token...");
-    let token = egg_mode::bearer_token(&con_token).await.unwrap();
+    let token = egg_mode::bearer_token(&con_token).await?;
 
     println!("Pulling up a user timeline...");
     let timeline =
         egg_mode::tweet::user_timeline("rustlang", false, true, &token).with_page_size(5);
 
-    let (_timeline, feed) = timeline.start().await.unwrap();
-    for tweet in feed {
+    let (_timeline, feed) = timeline.start().await?;
+    for tweet in feed.response {
         println!("");
         common::print_tweet(&tweet);
     }
+    Ok(())
 }

--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -40,7 +40,7 @@ impl Config {
         let consumer_key = include_str!("consumer_key").trim();
         let consumer_secret = include_str!("consumer_secret").trim();
 
-        let con_token = egg_mode::KeyPair::new(consumer_key, consumer_secret);
+        let con_token = egg_mode::KeyPair::new(dbg!(consumer_key), dbg!(consumer_secret));
 
         let mut config = String::new();
         let user_id: u64;

--- a/examples/conversations.rs
+++ b/examples/conversations.rs
@@ -12,7 +12,7 @@ async fn main() {
     let convos = convos.newest().await.unwrap();
 
     for (id, convo) in &convos.conversations {
-        let user = egg_mode::user::show(id, &c.token).await.unwrap();
+        let user = egg_mode::user::show(*id, &c.token).await.unwrap();
         println!("-----");
         println!("Conversation with @{}:", user.screen_name);
         for msg in convo {

--- a/examples/lists.rs
+++ b/examples/lists.rs
@@ -12,7 +12,7 @@ async fn main() {
 
     println!("Lists curated by user @Scobleizer:");
     let lists = list::list("Scobleizer", true, &config.token).await.unwrap();
-    for list in lists {
+    for list in lists.iter() {
         if list.user.screen_name == "Scobleizer" {
             println!("    {} ({})", list.name, list.slug);
         }

--- a/examples/reciprocal.rs
+++ b/examples/reciprocal.rs
@@ -18,13 +18,10 @@ async fn main() {
 
     println!("");
     let mut friends = HashSet::new();
-    user::friends_ids(config.user_id, &config.token)
+    let mut friends: HashSet<u64> = user::friends_ids(config.user_id, &config.token)
         .map(|r| r.unwrap().response)
-        .for_each(|id| {
-            friends.insert(id);
-            future::ready(())
-        })
-        .await;
+        .await
+        .collect();
 
     let mut followers = HashSet::new();
     user::followers_ids(config.user_id, &config.token)
@@ -46,7 +43,11 @@ async fn main() {
     );
 
     if reciprocals_ct > 0 {
-        for user in user::lookup(&reciprocals, &config.token).await.unwrap() {
+        for user in user::lookup(reciprocals, &config.token)
+            .await
+            .unwrap()
+            .iter()
+        {
             println!("{} (@{})", user.name, user.screen_name);
         }
     }

--- a/examples/reciprocal.rs
+++ b/examples/reciprocal.rs
@@ -4,33 +4,28 @@
 
 mod common;
 
-use futures::future;
-use futures::StreamExt;
+use futures::TryStreamExt;
 
+use egg_mode::error::Result;
 use egg_mode::user;
 use std::collections::HashSet;
 
 // IMPORTANT: see common.rs for instructions on making
 // sure this properly authenticates with Twitter.
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<()> {
     let config = common::Config::load().await;
 
     println!("");
-    let mut friends = HashSet::new();
-    let mut friends: HashSet<u64> = user::friends_ids(config.user_id, &config.token)
-        .map(|r| r.unwrap().response)
-        .await
-        .collect();
+    let friends: HashSet<u64> = user::friends_ids(config.user_id, &config.token)
+        .map_ok(|r| r.response)
+        .try_collect()
+        .await?;
 
-    let mut followers = HashSet::new();
-    user::followers_ids(config.user_id, &config.token)
-        .map(|r| r.unwrap().response)
-        .for_each(|id| {
-            followers.insert(id);
-            future::ready(())
-        })
-        .await;
+    let followers: HashSet<u64> = user::followers_ids(config.user_id, &config.token)
+        .map_ok(|r| r.response)
+        .try_collect()
+        .await?;
 
     let reciprocals = friends
         .intersection(&followers)
@@ -43,12 +38,9 @@ async fn main() {
     );
 
     if reciprocals_ct > 0 {
-        for user in user::lookup(reciprocals, &config.token)
-            .await
-            .unwrap()
-            .iter()
-        {
+        for user in user::lookup(reciprocals, &config.token).await?.iter() {
             println!("{} (@{})", user.name, user.screen_name);
         }
     }
+    Ok(())
 }

--- a/examples/thread.rs
+++ b/examples/thread.rs
@@ -4,11 +4,11 @@
 
 mod common;
 
-use egg_mode::tweet;
+use egg_mode::{error::Result, tweet};
 use std::collections::{HashSet, VecDeque};
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<()> {
     let c = common::Config::load().await;
 
     //Thread Reconstruction
@@ -42,14 +42,14 @@ async fn main() {
     let mut thread = VecDeque::with_capacity(21);
     let mut thread_ids = HashSet::new();
 
-    let start_tweet = tweet::show(start_id, &c.token).await.unwrap();
+    let start_tweet = tweet::show(start_id, &c.token).await?;
     let thread_user = start_tweet.user.as_ref().unwrap().id;
     thread_ids.insert(start_tweet.id);
     thread.push_front(start_tweet.response);
 
     for _ in 0usize..10 {
         if let Some(id) = thread.front().and_then(|t| t.in_reply_to_status_id) {
-            let parent = tweet::show(id, &c.token).await.unwrap();
+            let parent = tweet::show(id, &c.token).await?;
             thread_ids.insert(parent.id);
             thread.push_front(parent.response);
         } else {
@@ -61,15 +61,15 @@ async fn main() {
 
     for tweet in replies
         .call(Some(start_id), None)
-        .await
-        .unwrap()
+        .await?
+        .response
         .into_iter()
         .rev()
     {
         if let Some(reply_id) = tweet.in_reply_to_status_id {
             if thread_ids.contains(&reply_id) {
                 thread_ids.insert(tweet.id);
-                thread.push_back(tweet.response);
+                thread.push_back(tweet);
             }
         }
 
@@ -85,4 +85,5 @@ async fn main() {
         }
         common::print_tweet(&tweet);
     }
+    Ok(())
 }

--- a/examples/tweets.rs
+++ b/examples/tweets.rs
@@ -4,23 +4,23 @@
 
 mod common;
 
+use egg_mode::error::Result;
+
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<()> {
     let config = common::Config::load().await;
     let tweet_id = 766678057788829697;
 
     println!("");
     println!("Load up an individual tweet:");
-    let status = egg_mode::tweet::show(tweet_id, &config.token)
-        .await
-        .unwrap();
+    let status = egg_mode::tweet::show(tweet_id, &config.token).await?;
     common::print_tweet(&status);
 
     println!("");
     println!("Loading retweets of an individual tweet:");
-    for rt in &egg_mode::tweet::retweets_of(tweet_id, 5, &config.token)
-        .await
-        .unwrap()
+    for rt in egg_mode::tweet::retweets_of(tweet_id, 5, &config.token)
+        .await?
+        .iter()
     {
         if let Some(ref user) = rt.user {
             println!("{} (@{})", user.name, user.screen_name);
@@ -30,7 +30,7 @@ async fn main() {
     println!("");
     println!("Loading the user's home timeline:");
     let home = egg_mode::tweet::home_timeline(&config.token).with_page_size(5);
-    let (_home, feed) = home.start().await.unwrap();
+    let (_home, feed) = home.start().await?;
     for status in feed.iter() {
         common::print_tweet(&status);
         println!("");
@@ -39,7 +39,7 @@ async fn main() {
     println!("");
     println!("Loading the user's mentions timeline:");
     let mentions = egg_mode::tweet::mentions_timeline(&config.token).with_page_size(5);
-    let (_mentions, feed) = mentions.start().await.unwrap();
+    let (_mentions, feed) = mentions.start().await?;
     for status in feed.iter() {
         common::print_tweet(&status);
         println!("");
@@ -49,9 +49,10 @@ async fn main() {
     println!("Loading the user's timeline:");
     let user =
         egg_mode::tweet::user_timeline(config.user_id, true, true, &config.token).with_page_size(5);
-    let (_user, feed) = user.start().await.unwrap();
+    let (_user, feed) = user.start().await?;
     for status in feed.iter() {
         common::print_tweet(&status);
         println!("");
     }
+    Ok(())
 }

--- a/examples/tweets.rs
+++ b/examples/tweets.rs
@@ -31,7 +31,7 @@ async fn main() {
     println!("Loading the user's home timeline:");
     let home = egg_mode::tweet::home_timeline(&config.token).with_page_size(5);
     let (_home, feed) = home.start().await.unwrap();
-    for status in feed {
+    for status in feed.iter() {
         common::print_tweet(&status);
         println!("");
     }
@@ -40,7 +40,7 @@ async fn main() {
     println!("Loading the user's mentions timeline:");
     let mentions = egg_mode::tweet::mentions_timeline(&config.token).with_page_size(5);
     let (_mentions, feed) = mentions.start().await.unwrap();
-    for status in feed {
+    for status in feed.iter() {
         common::print_tweet(&status);
         println!("");
     }
@@ -50,7 +50,7 @@ async fn main() {
     let user =
         egg_mode::tweet::user_timeline(config.user_id, true, true, &config.token).with_page_size(5);
     let (_user, feed) = user.start().await.unwrap();
-    for status in feed {
+    for status in feed.iter() {
         common::print_tweet(&status);
         println!("");
     }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -574,7 +574,7 @@ pub fn post_json(uri: &str, token: &Token, body: &serde_json::Value) -> Request<
 ///     .unwrap();
 /// # }
 /// ```
-pub fn request_token<S: Into<String>>(con_token: &KeyPair, callback: S) -> TwitterFuture<KeyPair> {
+pub async fn request_token<S: Into<String>>(con_token: &KeyPair, callback: S) -> Result<KeyPair> {
     let header = get_header(
         Method::POST,
         links::auth::REQUEST_TOKEN,
@@ -615,7 +615,7 @@ pub fn request_token<S: Into<String>>(con_token: &KeyPair, callback: S) -> Twitt
         ))
     }
 
-    make_future(request, parse_tok)
+    make_future(request, parse_tok).await
 }
 
 /// With the given request KeyPair, return a URL that a user can access to accept or reject an
@@ -830,7 +830,7 @@ pub async fn access_token<S: Into<String>>(
 /// For more information, see the Twitter documentation on [Application-only authentication][auth].
 ///
 /// [auth]: https://dev.twitter.com/oauth/application-only
-pub fn bearer_token(con_token: &KeyPair) -> TwitterFuture<Token> {
+pub async fn bearer_token(con_token: &KeyPair) -> Result<Token> {
     let content = "application/x-www-form-urlencoded;charset=UTF-8";
 
     let auth_header = bearer_request(con_token);
@@ -850,7 +850,7 @@ pub fn bearer_token(con_token: &KeyPair) -> TwitterFuture<Token> {
         Ok(Token::Bearer(result.to_owned()))
     }
 
-    make_future(request, parse_tok)
+    make_future(request, parse_tok).await
 }
 
 /// Invalidate the given Bearer token using the given consumer KeyPair. Upon success, the future
@@ -859,7 +859,7 @@ pub fn bearer_token(con_token: &KeyPair) -> TwitterFuture<Token> {
 /// # Panics
 ///
 /// If this function is handed a `Token` that is not a Bearer token, this function will panic.
-pub fn invalidate_bearer(con_token: &KeyPair, token: &Token) -> TwitterFuture<Token> {
+pub async fn invalidate_bearer(con_token: &KeyPair, token: &Token) -> Result<Token> {
     let token = if let Token::Bearer(ref token) = *token {
         token
     } else {
@@ -886,7 +886,7 @@ pub fn invalidate_bearer(con_token: &KeyPair, token: &Token) -> TwitterFuture<To
         Ok(Token::Bearer(result.to_owned()))
     }
 
-    make_future(request, parse_tok)
+    make_future(request, parse_tok).await
 }
 
 /// If the given tokens are valid, return the user information for the authenticated user.

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -331,20 +331,14 @@ fn sign(
         let sig_params = params
             .cloned()
             .unwrap_or_default()
-            .add_param("oauth_consumer_key", header.consumer_key.as_str())
-            .add_param("oauth_nonce", header.nonce.as_str())
+            .add_param("oauth_consumer_key", header.consumer_key.clone())
+            .add_param("oauth_nonce", header.nonce.clone())
             .add_param("oauth_signature_method", "HMAC-SHA1")
-            .add_param("oauth_timestamp", format!("{}", header.timestamp))
+            .add_param("oauth_timestamp", format!("{}", header.timestamp.clone()))
             .add_param("oauth_version", "1.0")
-            .add_opt_param("oauth_token", header.token.as_ref().map(|t| t.as_str()))
-            .add_opt_param(
-                "oauth_callback",
-                header.callback.as_ref().map(|v| v.as_str()),
-            )
-            .add_opt_param(
-                "oauth_verifier",
-                header.verifier.as_ref().map(|v| v.as_str()),
-            );
+            .add_opt_param("oauth_token", header.token.clone())
+            .add_opt_param("oauth_callback", header.callback.clone())
+            .add_opt_param("oauth_verifier", header.verifier.clone());
 
         let mut query = sig_params
             .iter()

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -113,7 +113,9 @@
 
 use std::borrow::Cow;
 use std::collections::HashMap;
+use std::future::Future;
 use std::iter::Peekable;
+use std::pin::Pin;
 
 use chrono::{self, TimeZone};
 use hyper::header::{HeaderMap, HeaderValue};
@@ -124,7 +126,7 @@ use serde::{Deserialize, Deserializer};
 mod response;
 
 pub use crate::common::response::*;
-use crate::{list, user};
+use crate::{error, list, user};
 
 pub type Headers = HeaderMap<HeaderValue>;
 pub(crate) type CowStr = Cow<'static, str>;
@@ -228,7 +230,7 @@ where
 }
 
 ///Type alias for responses from Twitter.
-pub type WebResponse<T> = Result<Response<T>, crate::error::Error>;
+pub type WebResponse<T> = Result<Response<T>, error::Error>;
 
 ///Type alias for futures that resolve to responses from Twitter.
 ///
@@ -236,7 +238,7 @@ pub type WebResponse<T> = Result<Response<T>, crate::error::Error>;
 ///convenience alias that is only there so i don't have to write `Response<T>` all the time.
 ///
 ///[`TwitterFuture`]: struct.TwitterFuture.html
-pub type FutureResponse<T> = TwitterFuture<Response<T>>;
+pub type FutureResponse<T> = Pin<Box<dyn Future<Output = error::Result<Response<T>>>>>;
 
 pub fn codepoints_to_bytes(&mut (ref mut start, ref mut end): &mut (usize, usize), text: &str) {
     let mut byte_start = *start;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -173,17 +173,17 @@ impl ParamList {
         self.0.insert(key.into(), value.into());
     }
 
-    pub(crate) fn add_name_param(self, id: &user::UserID) -> Self {
-        match *id {
+    pub(crate) fn add_name_param(self, id: user::UserID) -> Self {
+        match id {
             user::UserID::ID(id) => self.add_param("user_id", id.to_string()),
             user::UserID::ScreenName(name) => self.add_param("screen_name", name),
         }
     }
 
-    pub(crate) fn add_list_param(mut self, list: &list::ListID) -> Self {
-        match *list {
-            list::ListID::Slug(ref owner, name) => {
-                match *owner {
+    pub(crate) fn add_list_param(mut self, list: list::ListID) -> Self {
+        match list {
+            list::ListID::Slug(owner, name) => {
+                match owner {
                     user::UserID::ID(id) => {
                         self.add_param_ref("owner_id", id.to_string());
                     }
@@ -191,7 +191,7 @@ impl ParamList {
                         self.add_param_ref("owner_screen_name", name);
                     }
                 }
-                self.add_param("slug", name)
+                self.add_param("slug", name.clone())
             }
             list::ListID::ID(id) => self.add_param("list_id", id.to_string()),
         }

--- a/src/common/response.rs
+++ b/src/common/response.rs
@@ -287,29 +287,6 @@ pub async fn make_future<T>(
     .await
 }
 
-pub fn make_future2<T>(
-    request: Request<Body>,
-    make_resp: fn(String, &Headers) -> Result<T>,
-) -> TwitterFuture<T> {
-    TwitterFuture {
-        request: make_raw_future(request),
-        make_resp: make_resp,
-    }
-}
-
-/// Shortcut function to create a `TwitterFuture` that parses out the given type from its response.
-pub async fn make_parsed_future<T: for<'de> Deserialize<'de>>(
-    request: Request<Body>,
-) -> Result<Response<T>> {
-    make_future(request, make_response).await
-}
-
-pub fn make_parsed_future2<T: for<'de> Deserialize<'de>>(
-    request: Request<Body>,
-) -> TwitterFuture<Response<T>> {
-    make_future2(request, make_response)
-}
-
 #[derive(Clone, Debug, Deserialize)]
 pub struct RateLimit {
     ///The rate limit ceiling for the given request.

--- a/src/common/response.rs
+++ b/src/common/response.rs
@@ -21,7 +21,6 @@ use serde_json;
 
 use std::convert::TryFrom;
 use std::future::Future;
-use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::{io, mem};
@@ -63,11 +62,15 @@ fn rate_limit_reset(headers: &Headers) -> Result<Option<i32>> {
 ///
 ///As this implements `Deref` and `DerefMut`, you can transparently use the contained `response`'s
 ///methods as if they were methods on this struct.
-#[derive(Debug, Deserialize, derive_more::Constructor)]
+#[derive(
+    Debug, Deserialize, derive_more::Constructor, derive_more::Deref, derive_more::DerefMut,
+)]
 pub struct Response<T> {
     /// Latest rate lime status
     pub rate_limit_status: RateLimit,
     ///The decoded response from the request.
+    #[deref]
+    #[deref_mut]
     pub response: T,
 }
 
@@ -94,20 +97,6 @@ impl<T> Response<T> {
             rate_limit_status: src.rate_limit_status,
             response: fun(src.response),
         }
-    }
-}
-
-impl<T> Deref for Response<T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        &self.response
-    }
-}
-
-impl<T> DerefMut for Response<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.response
     }
 }
 

--- a/src/common/response.rs
+++ b/src/common/response.rs
@@ -21,11 +21,10 @@ use serde_json;
 
 use std::convert::TryFrom;
 use std::future::Future;
-use std::iter::FromIterator;
 use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use std::{io, mem, slice, vec};
+use std::{io, mem};
 
 use super::Headers;
 
@@ -66,6 +65,7 @@ fn rate_limit_reset(headers: &Headers) -> Result<Option<i32>> {
 ///methods as if they were methods on this struct.
 #[derive(Debug, Deserialize, derive_more::Constructor)]
 pub struct Response<T> {
+    /// Latest rate lime status
     pub rate_limit_status: RateLimit,
     ///The decoded response from the request.
     pub response: T,
@@ -285,6 +285,13 @@ pub async fn make_future<T>(
         make_resp: make_resp,
     }
     .await
+}
+
+/// Shortcut function to create a `TwitterFuture` that parses out the given type from its response.
+pub async fn make_parsed_future<T: for<'de> Deserialize<'de>>(
+    request: Request<Body>,
+) -> Result<Response<T>> {
+    make_future(request, make_response).await
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/common/response.rs
+++ b/src/common/response.rs
@@ -563,7 +563,18 @@ pub fn make_response<T: for<'a> Deserialize<'a>>(
     Ok(Response::map(rate_headers(headers)?, |_| out))
 }
 
-pub fn make_future<T>(
+pub async fn make_future<T>(
+    request: Request<Body>,
+    make_resp: fn(String, &Headers) -> Result<T>,
+) -> Result<T> {
+    TwitterFuture {
+        request: make_raw_future(request),
+        make_resp: make_resp,
+    }
+    .await
+}
+
+pub fn make_future2<T>(
     request: Request<Body>,
     make_resp: fn(String, &Headers) -> Result<T>,
 ) -> TwitterFuture<T> {
@@ -583,7 +594,7 @@ pub async fn make_parsed_future<T: for<'de> Deserialize<'de>>(
 pub fn make_parsed_future2<T: for<'de> Deserialize<'de>>(
     request: Request<Body>,
 ) -> TwitterFuture<Response<T>> {
-    make_future(request, make_response)
+    make_future2(request, make_response)
 }
 
 pub fn rate_headers(resp: &Headers) -> Result<Response<()>> {

--- a/src/common/response.rs
+++ b/src/common/response.rs
@@ -16,7 +16,7 @@ use hyper::{self, Body, Request, StatusCode};
 use hyper_rustls::HttpsConnector;
 #[cfg(feature = "native_tls")]
 use hyper_tls::HttpsConnector;
-use serde::Deserialize;
+use serde::{de::DeserializeOwned, Deserialize};
 use serde_json;
 
 use std::convert::TryFrom;
@@ -267,10 +267,7 @@ impl<T> Future for TwitterFuture<T> {
 
 /// Shortcut `MakeResponse` method that attempts to parse the given type from the response and
 /// loads rate-limit information from the response headers.
-pub fn make_response<T: for<'a> Deserialize<'a>>(
-    body: String,
-    headers: &Headers,
-) -> Result<Response<T>> {
+pub fn make_response<T: DeserializeOwned>(body: String, headers: &Headers) -> Result<Response<T>> {
     let response = serde_json::from_str(&body)?;
     let rate_limit_status = RateLimit::try_from(headers)?;
     Ok(Response {

--- a/src/common/response.rs
+++ b/src/common/response.rs
@@ -283,7 +283,7 @@ pub async fn make_parsed_future<T: for<'de> Deserialize<'de>>(
     make_future(request, make_response).await
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Copy, Clone, Debug, Deserialize)]
 pub struct RateLimit {
     ///The rate limit ceiling for the given request.
     pub rate_limit: i32,

--- a/src/common/response.rs
+++ b/src/common/response.rs
@@ -67,10 +67,12 @@ fn rate_limit_reset(headers: &Headers) -> Result<Option<i32>> {
 )]
 pub struct Response<T> {
     /// Latest rate lime status
+    #[serde(flatten)]
     pub rate_limit_status: RateLimit,
     ///The decoded response from the request.
     #[deref]
     #[deref_mut]
+    #[serde(default)]
     pub response: T,
 }
 
@@ -286,20 +288,20 @@ pub async fn make_parsed_future<T: for<'de> Deserialize<'de>>(
 #[derive(Copy, Clone, Debug, Deserialize)]
 pub struct RateLimit {
     ///The rate limit ceiling for the given request.
-    pub rate_limit: i32,
+    pub limit: i32,
     ///The number of requests left for the 15-minute window.
-    pub rate_limit_remaining: i32,
+    pub remaining: i32,
     ///The UTC Unix timestamp at which the rate window resets.
-    pub rate_limit_reset: i32,
+    pub reset: i32,
 }
 
 impl TryFrom<&Headers> for RateLimit {
     type Error = Error;
     fn try_from(headers: &Headers) -> Result<Self> {
         Ok(Self {
-            rate_limit: rate_limit_limit(headers)?.unwrap_or(-1),
-            rate_limit_remaining: rate_limit_remaining(headers)?.unwrap_or(-1),
-            rate_limit_reset: rate_limit_reset(headers)?.unwrap_or(-1),
+            limit: rate_limit_limit(headers)?.unwrap_or(-1),
+            remaining: rate_limit_remaining(headers)?.unwrap_or(-1),
+            reset: rate_limit_reset(headers)?.unwrap_or(-1),
         })
     }
 }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -294,7 +294,7 @@ where
 
         let req = auth::get(self.link, &self.token, Some(&params));
 
-        make_parsed_future(req)
+        make_parsed_future2(req)
     }
 
     ///Creates a new instance of CursorIter, with the given parameters and empty initial results.

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -296,7 +296,7 @@ where
 
         let req = auth::get(self.link, &self.token, Some(&params));
 
-        make_parsed_future2(req)
+        make_parsed_future(req)
     }
 
     ///Creates a new instance of CursorIter, with the given parameters and empty initial results.

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -254,7 +254,7 @@ where
     ///implementation. It is made available for those who wish to manually manage network calls and
     ///pagination.
     pub next_cursor: i64,
-    loader: Option<Pin<Box<dyn Future<Output = Result<Response<T>>>>>>,
+    loader: Option<FutureResponse<T>>,
     iter: Option<VecIter<T::Item>>,
 }
 

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -164,18 +164,19 @@ impl Cursor for ListCursor {
 /// # #[tokio::main]
 /// # async fn main() {
 /// # let token: Token = unimplemented!();
-/// use futures::StreamExt;
+/// use futures::{StreamExt, TryStreamExt};
 /// use egg_mode::Response;
 /// use egg_mode::user::TwitterUser;
-/// use egg_mode::error::Error;
+/// use egg_mode::error::Result;
 ///
 /// // Because Streams don't have a FromIterator adaptor, we load all the responses first, then
 /// // collect them into the final Vec
-/// let names: Result<Response<Vec<TwitterUser>>, Error> =
-///     egg_mode::user::followers_of("rustlang", &token).take(10).collect::<Vec<_>>()
-///         .await
-///         .into_iter()
-///         .collect();
+/// let names: Result<Vec<TwitterUser>> =
+///     egg_mode::user::followers_of("rustlang", &token)
+///         .take(10)
+///         .map_ok(|r| r.response)
+///         .try_collect::<Vec<_>>()
+///         .await;
 /// # }
 /// ```
 ///

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -19,7 +19,7 @@ use serde::{de::DeserializeOwned, Deserialize};
 
 use crate::common::*;
 use crate::error::Result;
-use crate::{auth, error, list, user};
+use crate::{auth, list, user};
 
 ///Trait to generalize over paginated views of API results.
 ///

--- a/src/direct/fun.rs
+++ b/src/direct/fun.rs
@@ -40,7 +40,7 @@ pub async fn send<T: Into<UserID>>(
     token: &auth::Token,
 ) -> Result<Response<DirectMessage>, error::Error> {
     let params = ParamList::new()
-        .add_name_param(&to.into())
+        .add_name_param(to.into())
         .add_param("text", text);
 
     let req = auth::post(links::direct::SEND, token, Some(&params));

--- a/src/direct/fun.rs
+++ b/src/direct/fun.rs
@@ -34,9 +34,9 @@ pub fn sent(token: &auth::Token) -> Timeline {
 ///DM beforehand.
 ///
 ///Upon successfully sending the DM, the message will be returned.
-pub async fn send<'id, T: Into<UserID<'id>>>(
+pub async fn send<T: Into<UserID>>(
     to: T,
-    text: &str,
+    text: CowStr,
     token: &auth::Token,
 ) -> Result<Response<DirectMessage>, error::Error> {
     let params = ParamList::new()

--- a/src/direct/mod.rs
+++ b/src/direct/mod.rs
@@ -170,7 +170,7 @@ pub struct DMEntities {
 /// let mut timeline = egg_mode::direct::received(&token)
 ///                                     .with_page_size(10);
 ///
-/// for dm in &timeline.start().await.unwrap() {
+/// for dm in timeline.start().await.unwrap().iter() {
 ///     println!("<@{}> {}", dm.sender_screen_name, dm.text);
 /// }
 /// # }
@@ -186,7 +186,7 @@ pub struct DMEntities {
 /// # let token: Token = unimplemented!();
 /// # let mut timeline = egg_mode::direct::received(&token);
 /// # timeline.start().await.unwrap();
-/// for dm in &timeline.older(None).await.unwrap() {
+/// for dm in timeline.older(None).await.unwrap().iter() {
 ///     println!("<@{}> {}", dm.sender_screen_name, dm.text);
 /// }
 /// # }
@@ -424,7 +424,7 @@ fn merge(this: &mut DMConversations, conversations: DMConversations) {
 /// conversations = conversations.newest().await.unwrap();
 ///
 /// for (id, convo) in &conversations.conversations {
-///     let user = egg_mode::user::show(id, &token).await.unwrap();
+///     let user = egg_mode::user::show(*id, &token).await.unwrap();
 ///     println!("Conversation with @{}", user.screen_name);
 ///     for msg in convo {
 ///         println!("<@{}> {}", msg.sender_screen_name, msg.text);

--- a/src/direct/mod.rs
+++ b/src/direct/mod.rs
@@ -239,7 +239,7 @@ pub struct Timeline {
     ///The token used to authenticate requests with.
     token: auth::Token,
     ///Optional set of params to include prior to adding timeline navigation parameters.
-    params_base: Option<ParamList<'static>>,
+    params_base: Option<ParamList>,
     ///The maximum number of messages to return in a single call. Twitter doesn't guarantee
     ///returning exactly this number, as suspended or deleted content is removed after retrieving
     ///the initial collection of messages.
@@ -339,11 +339,7 @@ impl Timeline {
     }
 
     ///Create an instance of `Timeline` with the given link and tokens.
-    fn new(
-        link: &'static str,
-        params_base: Option<ParamList<'static>>,
-        token: &auth::Token,
-    ) -> Self {
+    fn new(link: &'static str, params_base: Option<ParamList>, token: &auth::Token) -> Self {
         Timeline {
             link: link,
             token: token.clone(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,7 +25,7 @@ use std::{self, fmt};
 use tokio;
 
 /// Convenient alias to a Result containing a local Error type
-pub(crate) type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, Error>;
 
 ///Represents a collection of errors returned from a Twitter API call.
 ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,7 +32,7 @@ pub(crate) type Result<T> = std::result::Result<T, Error>;
 ///This is returned as part of [`Error::TwitterError`][] whenever Twitter has rejected a call.
 ///
 ///[`Error::TwitterError`]: enum.Error.html
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, thiserror::Error)]
 pub struct TwitterErrors {
     ///A collection of errors returned by Twitter.
     pub errors: Vec<TwitterErrorCode>,
@@ -74,7 +74,8 @@ impl fmt::Display for TwitterErrorCode {
 }
 
 /// Represents an error that can occur during media processing.
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, thiserror::Error)]
+#[error("Media error {code} ({name}) - {message}")]
 pub struct MediaError {
     /// A numeric error code assigned to the error.
     pub code: i32,
@@ -85,34 +86,41 @@ pub struct MediaError {
 }
 
 /// A set of errors that can occur when interacting with Twitter.
-#[derive(Debug, derive_more::From)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     ///A URL was passed to a shortcut function that didn't match the method being called.
+    #[error("URL given did not match API method")]
     BadUrl,
     ///The response from Twitter was formatted incorrectly or in an unexpected manner. The enclosed
     ///values are an explanatory string and, if applicable, the input that caused the error.
     ///
     ///This usually reflects a bug in this library, as it means I'm not parsing input right.
+    #[error("Invalid response received: {} ({:?})", _0, _1)]
     InvalidResponse(&'static str, Option<String>),
     ///The response from Twitter was missing an expected value.  The enclosed value was the
     ///expected parameter.
     ///
     ///This usually reflects a bug in this library, as it means I'm expecting a value that may not
     ///always be there, and need to update my parsing to reflect this.
+    #[error("Value missing from response: {}", _0)]
     MissingValue(&'static str),
     ///The `Future` being polled has already returned a completed value (or another error). In
     ///order to retry the request, create the `Future` again.
+    #[error("Future has already completed")]
     FutureAlreadyCompleted,
     ///The response from Twitter returned an error structure instead of the expected response. The
     ///enclosed value was the response from Twitter.
-    TwitterError(TwitterErrors),
+    #[error("Errors returned by Twitter: {}", _0)]
+    TwitterError(#[from] TwitterErrors),
     ///The response returned from Twitter contained an error indicating that the rate limit for
     ///that method has been reached. The enclosed value is the Unix timestamp in UTC when the next
     ///rate-limit window will open.
+    #[error("Rate limit reached, hold until {}", _0)]
     RateLimit(i32),
     ///An attempt to upload a video or gif successfully uploaded the file, but failed in
     ///post-processing. The enclosed value contains the error message from Twitter.
-    MediaError(MediaError),
+    #[error("Error processing media: {}", _0)]
+    MediaError(#[from] MediaError),
     ///The response from Twitter gave a response code that indicated an error. The enclosed value
     ///was the response code.
     ///
@@ -120,100 +128,44 @@ pub enum Error {
     ///response body. That check is performed before examining the status code.
     ///
     ///[TwitterErrors]: struct.TwitterErrors.html
+    #[error("Error status received: {}", _0)]
     BadStatus(hyper::StatusCode),
     ///The web request experienced an error. The enclosed error was returned from hyper.
-    NetError(hyper::error::Error),
+    #[error("Network error: {}", _0)]
+    NetError(#[from] hyper::error::Error),
     ///The `native_tls` implementation returned an error. The enclosed error was returned from
     ///`native_tls`.
     #[cfg(feature = "native_tls")]
-    TlsError(native_tls::Error),
+    #[error("TLS error: {}", _0)]
+    TlsError(#[from] native_tls::Error),
     ///An error was experienced while processing the response stream. The enclosed error was
     ///returned from libstd.
-    IOError(std::io::Error),
+    #[error("IO error: {}", _0)]
+    IOError(#[from] std::io::Error),
     ///An error occurred while loading the JSON response. The enclosed error was returned from
     ///`serde_json`.
-    DeserializeError(serde_json::Error),
+    #[error("JSON deserialize error: {}", _0)]
+    DeserializeError(#[from] serde_json::Error),
     ///An error occurred when parsing a timestamp from Twitter. The enclosed error was returned
     ///from chrono.
-    TimestampParseError(chrono::ParseError),
+    #[error("Error parsing timestamp: {}", _0)]
+    TimestampParseError(#[from] chrono::ParseError),
     ///The tokio `Timer` instance was shut down while waiting on a timer, for example while waiting
     ///for media to be processed by Twitter. The enclosed error was returned from `tokio`.
-    TimerShutdownError(tokio::time::Error),
+    #[error("Timer runtime shutdown: {}", _0)]
+    TimerShutdownError(#[from] tokio::time::Error),
     ///An error occurred when reading the value from a response header. The enclused error was
     ///returned from hyper.
     ///
     ///This error should be considerably rare, but is included to ensure that egg-mode doesn't
     ///panic if it receives malformed headers or the like.
-    HeaderParseError(hyper::header::ToStrError),
+    #[error("Error decoding headers: {}", _0)]
+    HeaderParseError(#[from] hyper::header::ToStrError),
     ///An error occurred when converting a rate-limit header to an integer. The enclosed error was
     ///returned from the standard library.
     ///
     ///This error should be considerably rare, but is included to ensure that egg-mode doesn't
     ///panic if it receives malformed headers or the like.
-    HeaderConvertError(std::num::ParseIntError),
-}
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match *self {
-            Error::BadUrl => write!(f, "URL given did not match API method"),
-            Error::InvalidResponse(err, ref ext) => {
-                write!(f, "Invalid response received: {} ({:?})", err, ext)
-            }
-            Error::MissingValue(val) => write!(f, "Value missing from response: {}", val),
-            Error::FutureAlreadyCompleted => write!(f, "Future has already been completed"),
-            Error::TwitterError(ref err) => write!(f, "Error(s) returned from Twitter: {}", err),
-            Error::RateLimit(ts) => write!(f, "Rate limit reached, hold until {}", ts),
-            Error::MediaError(ref err) => write!(f, "Error processing media: {}", err.message),
-            Error::BadStatus(ref val) => write!(f, "Error status received: {}", val),
-            Error::NetError(ref err) => write!(f, "Network error: {}", err),
-            #[cfg(feature = "native_tls")]
-            Error::TlsError(ref err) => write!(f, "TLS error: {}", err),
-            Error::IOError(ref err) => write!(f, "IO error: {}", err),
-            Error::DeserializeError(ref err) => write!(f, "JSON deserialize error: {}", err),
-            Error::TimestampParseError(ref err) => write!(f, "Error parsing timestamp: {}", err),
-            Error::TimerShutdownError(ref err) => write!(f, "Timer runtime shutdown: {}", err),
-            Error::HeaderParseError(ref err) => write!(f, "Error decoding header: {}", err),
-            Error::HeaderConvertError(ref err) => write!(f, "Error converting header: {}", err),
-        }
-    }
-}
-
-impl std::error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::BadUrl => "URL given did not match API method",
-            Error::InvalidResponse(_, _) => "Invalid response received",
-            Error::MissingValue(_) => "Value missing from response",
-            Error::FutureAlreadyCompleted => "Future has already been completed",
-            Error::TwitterError(_) => "Error returned from Twitter",
-            Error::RateLimit(_) => "Rate limit for method reached",
-            Error::MediaError(_) => "Error processing media",
-            Error::BadStatus(_) => "Response included error code",
-            Error::NetError(ref err) => err.description(),
-            #[cfg(feature = "native_tls")]
-            Error::TlsError(ref err) => err.description(),
-            Error::IOError(ref err) => err.description(),
-            Error::DeserializeError(ref err) => err.description(),
-            Error::TimestampParseError(ref err) => err.description(),
-            Error::TimerShutdownError(ref err) => err.description(),
-            Error::HeaderParseError(ref err) => err.description(),
-            Error::HeaderConvertError(ref err) => err.description(),
-        }
-    }
-
-    fn cause(&self) -> Option<&dyn std::error::Error> {
-        match *self {
-            Error::NetError(ref err) => Some(err),
-            #[cfg(feature = "native_tls")]
-            Error::TlsError(ref err) => Some(err),
-            Error::IOError(ref err) => Some(err),
-            Error::TimestampParseError(ref err) => Some(err),
-            Error::DeserializeError(ref err) => Some(err),
-            Error::TimerShutdownError(ref err) => Some(err),
-            Error::HeaderParseError(ref err) => Some(err),
-            Error::HeaderConvertError(ref err) => Some(err),
-            _ => None,
-        }
-    }
+    #[error("Error converting headers: {}", _0)]
+    HeaderConvertError(#[from] std::num::ParseIntError),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,9 @@ use serde_json;
 use std::{self, fmt};
 use tokio;
 
+/// Convenient alias to a Result containing a local Error type
+pub(crate) type Result<T> = std::result::Result<T, Error>;
+
 ///Represents a collection of errors returned from a Twitter API call.
 ///
 ///This is returned as part of [`Error::TwitterError`][] whenever Twitter has rejected a call.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,6 +173,4 @@ pub use crate::auth::{
     access_token, authenticate_url, authorize_url, bearer_token, invalidate_bearer, request_token,
     verify_tokens, KeyPair, Token,
 };
-pub use crate::common::{
-    FutureResponse, Response, ResponseIter, ResponseIterMut, ResponseIterRef, TwitterFuture,
-};
+pub use crate::common::{FutureResponse, Response, TwitterFuture};

--- a/src/list/fun.rs
+++ b/src/list/fun.rs
@@ -2,8 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use std::convert::TryFrom;
+
 use super::*;
 
+use crate::common::RateLimit;
 use crate::cursor::{CursorIter, ListCursor, UserCursor};
 use crate::error::{Error::TwitterError, Result};
 use crate::user::{TwitterUser, UserID};
@@ -118,11 +121,11 @@ pub async fn is_subscribed<'id, T: Into<UserID<'id>>>(
             Ok(user) => Ok(Response::map(user, |_| true)),
             Err(TwitterError(terrs)) => {
                 if terrs.errors.iter().any(|e| e.code == 109) {
-                    //here's a fun conundrum: since "is not in this list" is returned as an error code,
-                    //the rate limit info that would otherwise be part of the response isn't there. the
-                    //rate_headers method was factored out specifically for this location, since it's
-                    //still there, just accompanying an error response instead of a user.
-                    Ok(Response::map(rate_headers(headers)?, |_| false))
+                    // here's a fun conundrum: since "is not in this list" is returned as an error code,
+                    // the rate limit info that would otherwise be part of the response isn't there. the
+                    // rate_headers method was factored out specifically for this location, since it's
+                    // still there, just accompanying an error response instead of a user.
+                    Ok(Response::new(RateLimit::try_from(headers)?, false))
                 } else {
                     Err(TwitterError(terrs))
                 }
@@ -153,11 +156,11 @@ pub async fn is_member<'id, T: Into<UserID<'id>>>(
             Ok(user) => Ok(Response::map(user, |_| true)),
             Err(TwitterError(terrs)) => {
                 if terrs.errors.iter().any(|e| e.code == 109) {
-                    //here's a fun conundrum: since "is not in this list" is returned as an error code,
-                    //the rate limit info that would otherwise be part of the response isn't there. the
-                    //rate_headers method was factored out specifically for this location, since it's
-                    //still there, just accompanying an error response instead of a user.
-                    Ok(Response::map(rate_headers(headers)?, |_| false))
+                    // here's a fun conundrum: since "is not in this list" is returned as an error code,
+                    // the rate limit info that would otherwise be part of the response isn't there. the
+                    // rate_headers method was factored out specifically for this location, since it's
+                    // still there, just accompanying an error response instead of a user.
+                    Ok(Response::new(RateLimit::try_from(headers)?, false))
                 } else {
                     Err(TwitterError(terrs))
                 }

--- a/src/list/fun.rs
+++ b/src/list/fun.rs
@@ -17,7 +17,7 @@ use crate::{auth, links, tweet};
 ///This function returns a `Stream` over the lists returned by Twitter. This method defaults to
 ///reeturning 20 lists in a single network call; the maximum is 1000.
 pub fn memberships<T: Into<UserID>>(user: T, token: &auth::Token) -> CursorIter<ListCursor> {
-    let params = ParamList::new().add_name_param(&user.into());
+    let params = ParamList::new().add_name_param(user.into());
     CursorIter::new(links::lists::MEMBERSHIPS, token, Some(params), Some(20))
 }
 
@@ -38,7 +38,7 @@ pub async fn list<'id, T: Into<UserID>>(
     token: &auth::Token,
 ) -> Result<Response<Vec<List>>> {
     let params = ParamList::new()
-        .add_name_param(&user.into())
+        .add_name_param(user.into())
         .add_param("reverse", owned_first.to_string());
 
     let req = auth::get(links::lists::LIST, token, Some(&params));
@@ -51,7 +51,7 @@ pub async fn list<'id, T: Into<UserID>>(
 ///This function returns a `Stream` over the lists returned by Twitter. This method defaults to
 ///reeturning 20 lists in a single network call; the maximum is 1000.
 pub fn subscriptions<T: Into<UserID>>(user: T, token: &auth::Token) -> CursorIter<ListCursor> {
-    let params = ParamList::new().add_name_param(&user.into());
+    let params = ParamList::new().add_name_param(user.into());
     CursorIter::new(links::lists::SUBSCRIPTIONS, token, Some(params), Some(20))
 }
 
@@ -60,13 +60,13 @@ pub fn subscriptions<T: Into<UserID>>(user: T, token: &auth::Token) -> CursorIte
 ///This function returns a `Stream` over the lists returned by Twitter. This method defaults to
 ///reeturning 20 lists in a single network call; the maximum is 1000.
 pub fn ownerships<T: Into<UserID>>(user: T, token: &auth::Token) -> CursorIter<ListCursor> {
-    let params = ParamList::new().add_name_param(&user.into());
+    let params = ParamList::new().add_name_param(user.into());
     CursorIter::new(links::lists::OWNERSHIPS, token, Some(params), Some(20))
 }
 
 ///Look up information for a single list.
 pub async fn show(list: ListID, token: &auth::Token) -> Result<Response<List>> {
-    let params = ParamList::new().add_list_param(&list);
+    let params = ParamList::new().add_list_param(list);
 
     let req = auth::get(links::lists::SHOW, token, Some(&params));
 
@@ -78,7 +78,7 @@ pub async fn show(list: ListID, token: &auth::Token) -> Result<Response<List>> {
 ///This function returns a `Stream` over the users returned by Twitter. This method defaults to
 ///reeturning 20 users in a single network call; the maximum is 5000.
 pub fn members<'a>(list: ListID, token: &auth::Token) -> CursorIter<UserCursor> {
-    let params = ParamList::new().add_list_param(&list);
+    let params = ParamList::new().add_list_param(list);
 
     CursorIter::new(links::lists::MEMBERS, token, Some(params), Some(20))
 }
@@ -88,7 +88,7 @@ pub fn members<'a>(list: ListID, token: &auth::Token) -> CursorIter<UserCursor> 
 ///This function returns a `Stream` over the users returned by Twitter. This method defaults to
 ///reeturning 20 users in a single network call; the maximum is 5000.
 pub fn subscribers<'a>(list: ListID, token: &auth::Token) -> CursorIter<UserCursor> {
-    let params = ParamList::new().add_list_param(&list);
+    let params = ParamList::new().add_list_param(list);
 
     CursorIter::new(links::lists::SUBSCRIBERS, token, Some(params), Some(20))
 }
@@ -100,8 +100,8 @@ pub async fn is_subscribed<'id, T: Into<UserID>>(
     token: &auth::Token,
 ) -> Result<Response<bool>> {
     let params = ParamList::new()
-        .add_list_param(&list)
-        .add_name_param(&user.into());
+        .add_list_param(list)
+        .add_name_param(user.into());
 
     let req = auth::get(links::lists::IS_SUBSCRIBER, token, Some(&params));
 
@@ -135,8 +135,8 @@ pub async fn is_member<'id, T: Into<UserID>>(
     token: &auth::Token,
 ) -> Result<Response<bool>> {
     let params = ParamList::new()
-        .add_list_param(&list)
-        .add_name_param(&user.into());
+        .add_list_param(list)
+        .add_name_param(user.into());
 
     let req = auth::get(links::lists::IS_MEMBER, token, Some(&params));
 
@@ -171,7 +171,7 @@ pub async fn is_member<'id, T: Into<UserID>>(
 ///[`Timeline`]: ../tweet/struct.Timeline.html
 pub fn statuses(list: ListID, with_rts: bool, token: &auth::Token) -> tweet::Timeline {
     let params = ParamList::new()
-        .add_list_param(&list)
+        .add_list_param(list)
         .add_param("include_rts", with_rts.to_string());
 
     tweet::Timeline::new(links::lists::STATUSES, Some(params), token)
@@ -188,8 +188,8 @@ pub async fn add_member<'id, T: Into<UserID>>(
     token: &auth::Token,
 ) -> Result<Response<List>> {
     let params = ParamList::new()
-        .add_list_param(&list)
-        .add_name_param(&user.into());
+        .add_list_param(list)
+        .add_name_param(user.into());
 
     let req = auth::post(links::lists::ADD, token, Some(&params));
 
@@ -220,7 +220,7 @@ where
 {
     let (id_param, name_param) = multiple_names_param(members);
     let params = ParamList::new()
-        .add_list_param(&list)
+        .add_list_param(list)
         .add_opt_param(
             "user_id",
             if !id_param.is_empty() {
@@ -250,8 +250,8 @@ pub async fn remove_member<'id, T: Into<UserID>>(
     token: &auth::Token,
 ) -> Result<Response<List>> {
     let params = ParamList::new()
-        .add_list_param(&list)
-        .add_name_param(&user.into());
+        .add_list_param(list)
+        .add_name_param(user.into());
 
     let req = auth::post(links::lists::REMOVE_MEMBER, token, Some(&params));
 
@@ -281,7 +281,7 @@ where
 {
     let (id_param, name_param) = multiple_names_param(members);
     let params = ParamList::new()
-        .add_list_param(&list)
+        .add_list_param(list)
         .add_opt_param(
             "user_id",
             if !id_param.is_empty() {
@@ -329,7 +329,7 @@ pub async fn create(
 ///
 ///The authenticated user must have created the list.
 pub async fn delete(list: ListID, token: &auth::Token) -> Result<Response<List>> {
-    let params = ParamList::new().add_list_param(&list);
+    let params = ParamList::new().add_list_param(list);
 
     let req = auth::post(links::lists::DELETE, token, Some(&params));
 
@@ -341,7 +341,7 @@ pub async fn delete(list: ListID, token: &auth::Token) -> Result<Response<List>>
 ///Subscribing to a list is a way to make it available in the "Lists" section of a user's profile
 ///without having to create it themselves.
 pub async fn subscribe(list: ListID, token: &auth::Token) -> Result<Response<List>> {
-    let params = ParamList::new().add_list_param(&list);
+    let params = ParamList::new().add_list_param(list);
 
     let req = auth::post(links::lists::SUBSCRIBE, token, Some(&params));
 
@@ -350,7 +350,7 @@ pub async fn subscribe(list: ListID, token: &auth::Token) -> Result<Response<Lis
 
 ///Unsubscribes the authenticated user from the given list.
 pub async fn unsubscribe(list: ListID, token: &auth::Token) -> Result<Response<List>> {
-    let params = ParamList::new().add_list_param(&list);
+    let params = ParamList::new().add_list_param(list);
 
     let req = auth::post(links::lists::UNSUBSCRIBE, token, Some(&params));
 

--- a/src/list/fun.rs
+++ b/src/list/fun.rs
@@ -16,10 +16,7 @@ use crate::{auth, links, tweet};
 ///
 ///This function returns a `Stream` over the lists returned by Twitter. This method defaults to
 ///reeturning 20 lists in a single network call; the maximum is 1000.
-pub fn memberships<'a, T: Into<UserID<'a>>>(
-    user: T,
-    token: &auth::Token,
-) -> CursorIter<'a, ListCursor> {
+pub fn memberships<T: Into<UserID>>(user: T, token: &auth::Token) -> CursorIter<ListCursor> {
     let params = ParamList::new().add_name_param(&user.into());
     CursorIter::new(links::lists::MEMBERSHIPS, token, Some(params), Some(20))
 }
@@ -35,7 +32,7 @@ pub fn memberships<'a, T: Into<UserID<'a>>>(
 ///
 ///If the user has more than 100 lists total like this, you'll need to call `ownerships` and
 ///`subscriptions` separately to be able to properly load everything.
-pub async fn list<'id, T: Into<UserID<'id>>>(
+pub async fn list<'id, T: Into<UserID>>(
     user: T,
     owned_first: bool,
     token: &auth::Token,
@@ -53,10 +50,7 @@ pub async fn list<'id, T: Into<UserID<'id>>>(
 ///
 ///This function returns a `Stream` over the lists returned by Twitter. This method defaults to
 ///reeturning 20 lists in a single network call; the maximum is 1000.
-pub fn subscriptions<'a, T: Into<UserID<'a>>>(
-    user: T,
-    token: &auth::Token,
-) -> CursorIter<'a, ListCursor> {
+pub fn subscriptions<T: Into<UserID>>(user: T, token: &auth::Token) -> CursorIter<ListCursor> {
     let params = ParamList::new().add_name_param(&user.into());
     CursorIter::new(links::lists::SUBSCRIPTIONS, token, Some(params), Some(20))
 }
@@ -65,16 +59,13 @@ pub fn subscriptions<'a, T: Into<UserID<'a>>>(
 ///
 ///This function returns a `Stream` over the lists returned by Twitter. This method defaults to
 ///reeturning 20 lists in a single network call; the maximum is 1000.
-pub fn ownerships<'a, T: Into<UserID<'a>>>(
-    user: T,
-    token: &auth::Token,
-) -> CursorIter<'a, ListCursor> {
+pub fn ownerships<T: Into<UserID>>(user: T, token: &auth::Token) -> CursorIter<ListCursor> {
     let params = ParamList::new().add_name_param(&user.into());
     CursorIter::new(links::lists::OWNERSHIPS, token, Some(params), Some(20))
 }
 
 ///Look up information for a single list.
-pub async fn show(list: ListID<'_>, token: &auth::Token) -> Result<Response<List>> {
+pub async fn show(list: ListID, token: &auth::Token) -> Result<Response<List>> {
     let params = ParamList::new().add_list_param(&list);
 
     let req = auth::get(links::lists::SHOW, token, Some(&params));
@@ -86,7 +77,7 @@ pub async fn show(list: ListID<'_>, token: &auth::Token) -> Result<Response<List
 ///
 ///This function returns a `Stream` over the users returned by Twitter. This method defaults to
 ///reeturning 20 users in a single network call; the maximum is 5000.
-pub fn members<'a>(list: ListID<'a>, token: &auth::Token) -> CursorIter<'a, UserCursor> {
+pub fn members<'a>(list: ListID, token: &auth::Token) -> CursorIter<UserCursor> {
     let params = ParamList::new().add_list_param(&list);
 
     CursorIter::new(links::lists::MEMBERS, token, Some(params), Some(20))
@@ -96,16 +87,16 @@ pub fn members<'a>(list: ListID<'a>, token: &auth::Token) -> CursorIter<'a, User
 ///
 ///This function returns a `Stream` over the users returned by Twitter. This method defaults to
 ///reeturning 20 users in a single network call; the maximum is 5000.
-pub fn subscribers<'a>(list: ListID<'a>, token: &auth::Token) -> CursorIter<'a, UserCursor> {
+pub fn subscribers<'a>(list: ListID, token: &auth::Token) -> CursorIter<UserCursor> {
     let params = ParamList::new().add_list_param(&list);
 
     CursorIter::new(links::lists::SUBSCRIBERS, token, Some(params), Some(20))
 }
 
 ///Check whether the given user is subscribed to the given list.
-pub async fn is_subscribed<'id, T: Into<UserID<'id>>>(
+pub async fn is_subscribed<'id, T: Into<UserID>>(
     user: T,
-    list: ListID<'_>,
+    list: ListID,
     token: &auth::Token,
 ) -> Result<Response<bool>> {
     let params = ParamList::new()
@@ -138,9 +129,9 @@ pub async fn is_subscribed<'id, T: Into<UserID<'id>>>(
 }
 
 ///Check whether the given user has been added to the given list.
-pub async fn is_member<'id, T: Into<UserID<'id>>>(
+pub async fn is_member<'id, T: Into<UserID>>(
     user: T,
-    list: ListID<'_>,
+    list: ListID,
     token: &auth::Token,
 ) -> Result<Response<bool>> {
     let params = ParamList::new()
@@ -178,7 +169,7 @@ pub async fn is_member<'id, T: Into<UserID<'id>>>(
 ///timeline. see the [`Timeline`] docs for details.
 ///
 ///[`Timeline`]: ../tweet/struct.Timeline.html
-pub fn statuses<'a>(list: ListID<'a>, with_rts: bool, token: &auth::Token) -> tweet::Timeline<'a> {
+pub fn statuses(list: ListID, with_rts: bool, token: &auth::Token) -> tweet::Timeline {
     let params = ParamList::new()
         .add_list_param(&list)
         .add_param("include_rts", with_rts.to_string());
@@ -191,8 +182,8 @@ pub fn statuses<'a>(list: ListID<'a>, with_rts: bool, token: &auth::Token) -> tw
 ///Note that lists cannot have more than 5000 members.
 ///
 ///Upon success, the future returned by this function yields the freshly-modified list.
-pub async fn add_member<'id, T: Into<UserID<'id>>>(
-    list: ListID<'_>,
+pub async fn add_member<'id, T: Into<UserID>>(
+    list: ListID,
     user: T,
     token: &auth::Token,
 ) -> Result<Response<List>> {
@@ -220,11 +211,11 @@ pub async fn add_member<'id, T: Into<UserID<'id>>>(
 ///immediately available for a corresponding removal or addition, respectively.
 pub async fn add_member_list<'id, T, I>(
     members: I,
-    list: ListID<'_>,
+    list: ListID,
     token: &auth::Token,
 ) -> Result<Response<List>>
 where
-    T: Into<UserID<'id>>,
+    T: Into<UserID>,
     I: IntoIterator<Item = T>,
 {
     let (id_param, name_param) = multiple_names_param(members);
@@ -253,8 +244,8 @@ where
 }
 
 ///Removes the given user from the given list.
-pub async fn remove_member<'id, T: Into<UserID<'id>>>(
-    list: ListID<'_>,
+pub async fn remove_member<'id, T: Into<UserID>>(
+    list: ListID,
     user: T,
     token: &auth::Token,
 ) -> Result<Response<List>> {
@@ -279,13 +270,13 @@ pub async fn remove_member<'id, T: Into<UserID<'id>>>(
 ///When using this method, take care not to add and remove many members in rapid succession; there
 ///are no guarantees that the result of a `add_member_list` or `remove_member_list` will be
 ///immediately available for a corresponding removal or addition, respectively.
-pub async fn remove_member_list<'a, T, I>(
+pub async fn remove_member_list<T, I>(
     members: I,
-    list: ListID<'_>,
+    list: ListID,
     token: &auth::Token,
 ) -> Result<Response<List>>
 where
-    T: Into<UserID<'a>>,
+    T: Into<UserID>,
     I: IntoIterator<Item = T>,
 {
     let (id_param, name_param) = multiple_names_param(members);
@@ -319,9 +310,9 @@ where
 ///and the name given to `name`. Twitter places an upper limit on 1000 lists owned by a single
 ///account.
 pub async fn create(
-    name: &str,
+    name: String,
     public: bool,
-    desc: Option<&str>,
+    desc: Option<String>,
     token: &auth::Token,
 ) -> Result<Response<List>> {
     let params = ParamList::new()
@@ -337,7 +328,7 @@ pub async fn create(
 ///Deletes the given list.
 ///
 ///The authenticated user must have created the list.
-pub async fn delete(list: ListID<'_>, token: &auth::Token) -> Result<Response<List>> {
+pub async fn delete(list: ListID, token: &auth::Token) -> Result<Response<List>> {
     let params = ParamList::new().add_list_param(&list);
 
     let req = auth::post(links::lists::DELETE, token, Some(&params));
@@ -349,7 +340,7 @@ pub async fn delete(list: ListID<'_>, token: &auth::Token) -> Result<Response<Li
 ///
 ///Subscribing to a list is a way to make it available in the "Lists" section of a user's profile
 ///without having to create it themselves.
-pub async fn subscribe(list: ListID<'_>, token: &auth::Token) -> Result<Response<List>> {
+pub async fn subscribe(list: ListID, token: &auth::Token) -> Result<Response<List>> {
     let params = ParamList::new().add_list_param(&list);
 
     let req = auth::post(links::lists::SUBSCRIBE, token, Some(&params));
@@ -358,7 +349,7 @@ pub async fn subscribe(list: ListID<'_>, token: &auth::Token) -> Result<Response
 }
 
 ///Unsubscribes the authenticated user from the given list.
-pub async fn unsubscribe(list: ListID<'_>, token: &auth::Token) -> Result<Response<List>> {
+pub async fn unsubscribe(list: ListID, token: &auth::Token) -> Result<Response<List>> {
     let params = ParamList::new().add_list_param(&list);
 
     let req = auth::post(links::lists::UNSUBSCRIBE, token, Some(&params));
@@ -371,7 +362,7 @@ pub async fn unsubscribe(list: ListID<'_>, token: &auth::Token) -> Result<Respon
 ///This method is exposed using a builder struct. See the [`ListUpdate`] docs for details.
 ///
 ///[`ListUpdate`]: struct.ListUpdate.html
-pub fn update<'a>(list: ListID<'a>) -> ListUpdate<'a> {
+pub fn update(list: ListID) -> ListUpdate {
     ListUpdate {
         list: list,
         name: None,

--- a/src/list/mod.rs
+++ b/src/list/mod.rs
@@ -109,8 +109,8 @@ pub enum ListID {
 
 impl ListID {
     ///Make a new `ListID` by supplying its owner and name.
-    pub fn from_slug<T: Into<user::UserID>>(owner: T, list_name: CowStr) -> ListID {
-        ListID::Slug(owner.into(), list_name)
+    pub fn from_slug<T: Into<user::UserID>>(owner: T, list_name: impl Into<CowStr>) -> ListID {
+        ListID::Slug(owner.into(), list_name.into())
     }
 
     ///Make a new `ListID` by supplying its numeric ID.

--- a/src/list/mod.rs
+++ b/src/list/mod.rs
@@ -217,7 +217,7 @@ impl<'a> ListUpdate<'a> {
     }
 
     ///Sends the update request to Twitter.
-    pub fn send(self, token: &auth::Token) -> FutureResponse<List> {
+    pub async fn send(self, token: &auth::Token) -> Result<Response<List>, crate::error::Error> {
         let params = ParamList::new()
             .add_list_param(&self.list)
             .add_opt_param("name", self.name)
@@ -228,8 +228,7 @@ impl<'a> ListUpdate<'a> {
             .add_opt_param("description", self.desc);
 
         let req = auth::post(links::lists::UPDATE, token, Some(&params));
-
-        make_parsed_future(req)
+        make_parsed_future(req).await
     }
 }
 

--- a/src/list/mod.rs
+++ b/src/list/mod.rs
@@ -219,7 +219,7 @@ impl ListUpdate {
     ///Sends the update request to Twitter.
     pub async fn send(self, token: &auth::Token) -> Result<Response<List>, crate::error::Error> {
         let params = ParamList::new()
-            .add_list_param(&self.list)
+            .add_list_param(self.list)
             .add_opt_param("name", self.name)
             .add_opt_param(
                 "mode",

--- a/src/list/mod.rs
+++ b/src/list/mod.rs
@@ -71,7 +71,7 @@ use chrono;
 use serde::Deserialize;
 
 use crate::common::*;
-use crate::{auth, error, links, user};
+use crate::{auth, links, user};
 
 mod fun;
 pub use self::fun::*;

--- a/src/list/mod.rs
+++ b/src/list/mod.rs
@@ -99,22 +99,22 @@ pub use self::fun::*;
 /// let slug = ListID::from_slug("Twitter", "support");
 /// let id = ListID::from_id(99924643);
 /// ```
-#[derive(Debug, Copy, Clone)]
-pub enum ListID<'a> {
+#[derive(Debug, Clone)]
+pub enum ListID {
     ///Referring via the list's owner and its "slug" or name.
-    Slug(user::UserID<'a>, &'a str),
+    Slug(user::UserID, CowStr),
     ///Referring via the list's numeric ID.
     ID(u64),
 }
 
-impl<'a> ListID<'a> {
+impl ListID {
     ///Make a new `ListID` by supplying its owner and name.
-    pub fn from_slug<T: Into<user::UserID<'a>>>(owner: T, list_name: &'a str) -> ListID<'a> {
+    pub fn from_slug<T: Into<user::UserID>>(owner: T, list_name: CowStr) -> ListID {
         ListID::Slug(owner.into(), list_name)
     }
 
     ///Make a new `ListID` by supplying its numeric ID.
-    pub fn from_id(list_id: u64) -> ListID<'a> {
+    pub fn from_id(list_id: u64) -> ListID {
         ListID::ID(list_id)
     }
 }
@@ -184,16 +184,16 @@ pub struct List {
 /// let list = update.name("Official Support").send(&token).await.unwrap();
 /// # }
 /// ```
-pub struct ListUpdate<'a> {
-    list: ListID<'a>,
-    name: Option<&'a str>,
+pub struct ListUpdate {
+    list: ListID,
+    name: Option<String>,
     public: Option<bool>,
-    desc: Option<&'a str>,
+    desc: Option<String>,
 }
 
-impl<'a> ListUpdate<'a> {
+impl ListUpdate {
     ///Updates the name of the list.
-    pub fn name(self, name: &'a str) -> ListUpdate<'a> {
+    pub fn name(self, name: String) -> ListUpdate {
         ListUpdate {
             name: Some(name),
             ..self
@@ -201,7 +201,7 @@ impl<'a> ListUpdate<'a> {
     }
 
     ///Sets whether the list is public.
-    pub fn public(self, public: bool) -> ListUpdate<'a> {
+    pub fn public(self, public: bool) -> ListUpdate {
         ListUpdate {
             public: Some(public),
             ..self
@@ -209,7 +209,7 @@ impl<'a> ListUpdate<'a> {
     }
 
     ///Updates the description of the list.
-    pub fn desc(self, desc: &'a str) -> ListUpdate<'a> {
+    pub fn desc(self, desc: String) -> ListUpdate {
         ListUpdate {
             desc: Some(desc),
             ..self

--- a/src/list/mod.rs
+++ b/src/list/mod.rs
@@ -193,9 +193,9 @@ pub struct ListUpdate {
 
 impl ListUpdate {
     ///Updates the name of the list.
-    pub fn name(self, name: String) -> ListUpdate {
+    pub fn name(self, name: impl Into<String>) -> ListUpdate {
         ListUpdate {
-            name: Some(name),
+            name: Some(name.into()),
             ..self
         }
     }

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -427,7 +427,7 @@ impl<'a> UploadFuture<'a> {
             .add_param("media_category", self.media_category.to_string());
 
         let req = auth::post(links::media::UPLOAD, &self.token, Some(&params));
-        make_parsed_future(req)
+        make_parsed_future2(req)
     }
 
     fn append(&self, chunk_num: usize, media_id: u64) -> Option<FutureResponse<()>> {
@@ -468,7 +468,7 @@ impl<'a> UploadFuture<'a> {
             .add_param("media_id", media_id.to_string());
 
         let req = auth::post(links::media::UPLOAD, &self.token, Some(&params));
-        make_parsed_future(req)
+        make_parsed_future2(req)
     }
 
     fn status(&self, media_id: u64) -> FutureResponse<RawMedia> {
@@ -477,7 +477,7 @@ impl<'a> UploadFuture<'a> {
             .add_param("media_id", media_id.to_string());
 
         let req = auth::get(links::media::UPLOAD, &self.token, Some(&params));
-        make_parsed_future(req)
+        make_parsed_future2(req)
     }
 
     fn metadata(&self, media_id: u64, alt_text: &str) -> FutureResponse<()> {

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -168,10 +168,10 @@ pub struct MediaHandle {
 }
 
 impl MediaHandle {
-    #[inline]
     /// Returns whether media is still valid to be used in API calls.
     ///
     /// Under hood it is `Instant::now() < handle.valid_until`.
+    #[inline]
     pub fn is_valid(&self) -> bool {
         Instant::now() < self.valid_until
     }

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -171,7 +171,6 @@ impl MediaHandle {
     /// Returns whether media is still valid to be used in API calls.
     ///
     /// Under hood it is `Instant::now() < handle.valid_until`.
-    #[inline]
     pub fn is_valid(&self) -> bool {
         Instant::now() < self.valid_until
     }

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -456,7 +456,7 @@ impl<'a> UploadFuture<'a> {
                 }
             }
 
-            Some(make_future(req, parse_resp))
+            Some(make_future2(req, parse_resp))
         } else {
             None
         }
@@ -503,7 +503,7 @@ impl<'a> UploadFuture<'a> {
             }
         }
 
-        make_future(req, parse_resp)
+        make_future2(req, parse_resp)
     }
 }
 

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -450,7 +450,7 @@ impl<'a> UploadFuture<'a> {
                 headers: &Headers,
             ) -> Result<Response<()>, error::Error> {
                 if full_resp.is_empty() {
-                    rate_headers(headers)
+                    Response::unit(headers)
                 } else {
                     Err(InvalidResponse("Expected empty response", Some(full_resp)))
                 }
@@ -497,7 +497,7 @@ impl<'a> UploadFuture<'a> {
 
         fn parse_resp(full_resp: String, headers: &Headers) -> Result<Response<()>, error::Error> {
             if full_resp.is_empty() {
-                rate_headers(headers)
+                Response::unit(headers)
             } else {
                 Err(InvalidResponse("Expected empty response", Some(full_resp)))
             }

--- a/src/place/fun.rs
+++ b/src/place/fun.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use crate::common::*;
-use crate::error::{Error::BadUrl, Result};
+use crate::error::{Error, Result};
 use crate::{auth, links};
 
 use super::PlaceQuery;
@@ -52,28 +52,27 @@ pub fn reverse_geocode(latitude: f64, longitude: f64) -> GeocodeBuilder {
     GeocodeBuilder::new(latitude, longitude)
 }
 
-fn parse_url<'a>(base: &'static str, full: &'a str) -> Result<ParamList> {
-    // let mut iter = full.split('?');
+fn parse_url(base: &'static str, full: &str) -> Result<ParamList> {
+    let mut iter = full.split('?');
 
-    // if let Some(base_part) = iter.next() {
-    //     if base_part != base {
-    //         return Err(BadUrl);
-    //     }
-    // } else {
-    //     return Err(BadUrl);
-    // }
+    if let Some(base_part) = iter.next() {
+        if base_part != base {
+            return Err(Error::BadUrl);
+        }
+    } else {
+        return Err(Error::BadUrl);
+    }
 
-    // if let Some(list) = iter.next() {
-    //     list.split('&').try_fold(ParamList::new(), |p, pair| {
-    //         let mut kv_iter = pair.split('=');
-    //         let k = kv_iter.next().ok_or(BadUrl)?;
-    //         let v = kv_iter.next().ok_or(BadUrl)?;
-    //         Ok(p.add_param(k, v))
-    //     })
-    // } else {
-    //     Err(BadUrl)
-    // }
-    todo!()
+    if let Some(list) = iter.next() {
+        list.split('&').try_fold(ParamList::new(), |p, pair| {
+            let mut kv_iter = pair.split('=');
+            let k = kv_iter.next().ok_or(Error::BadUrl)?;
+            let v = kv_iter.next().ok_or(Error::BadUrl)?;
+            Ok(p.add_param(k.to_string(), v.to_string()))
+        })
+    } else {
+        Err(Error::BadUrl)
+    }
 }
 
 ///From a URL given with the result of `reverse_geocode`, perform the same reverse-geocode search.

--- a/src/place/fun.rs
+++ b/src/place/fun.rs
@@ -52,27 +52,28 @@ pub fn reverse_geocode(latitude: f64, longitude: f64) -> GeocodeBuilder {
     GeocodeBuilder::new(latitude, longitude)
 }
 
-fn parse_url<'a>(base: &'static str, full: &'a str) -> Result<ParamList<'a>> {
-    let mut iter = full.split('?');
+fn parse_url<'a>(base: &'static str, full: &'a str) -> Result<ParamList> {
+    // let mut iter = full.split('?');
 
-    if let Some(base_part) = iter.next() {
-        if base_part != base {
-            return Err(BadUrl);
-        }
-    } else {
-        return Err(BadUrl);
-    }
+    // if let Some(base_part) = iter.next() {
+    //     if base_part != base {
+    //         return Err(BadUrl);
+    //     }
+    // } else {
+    //     return Err(BadUrl);
+    // }
 
-    if let Some(list) = iter.next() {
-        list.split('&').try_fold(ParamList::new(), |p, pair| {
-            let mut kv_iter = pair.split('=');
-            let k = kv_iter.next().ok_or(BadUrl)?;
-            let v = kv_iter.next().ok_or(BadUrl)?;
-            Ok(p.add_param(k, v))
-        })
-    } else {
-        Err(BadUrl)
-    }
+    // if let Some(list) = iter.next() {
+    //     list.split('&').try_fold(ParamList::new(), |p, pair| {
+    //         let mut kv_iter = pair.split('=');
+    //         let k = kv_iter.next().ok_or(BadUrl)?;
+    //         let v = kv_iter.next().ok_or(BadUrl)?;
+    //         Ok(p.add_param(k, v))
+    //     })
+    // } else {
+    //     Err(BadUrl)
+    // }
+    todo!()
 }
 
 ///From a URL given with the result of `reverse_geocode`, perform the same reverse-geocode search.
@@ -106,7 +107,7 @@ pub async fn reverse_geocode_url(url: &str, token: &auth::Token) -> Result<Respo
 /// assert!(result.results.iter().any(|pl| pl.full_name == "London, England"));
 /// # }
 /// ```
-pub fn search_point(latitude: f64, longitude: f64) -> SearchBuilder<'static> {
+pub fn search_point(latitude: f64, longitude: f64) -> SearchBuilder {
     SearchBuilder::new(PlaceQuery::LatLon(latitude, longitude))
 }
 
@@ -129,12 +130,12 @@ pub fn search_point(latitude: f64, longitude: f64) -> SearchBuilder<'static> {
 /// assert!(result.results.iter().any(|pl| pl.full_name == "British Columbia, Canada"));
 /// # }
 /// ```
-pub fn search_query<'a>(query: &'a str) -> SearchBuilder<'a> {
+pub fn search_query(query: String) -> SearchBuilder {
     SearchBuilder::new(PlaceQuery::Query(query))
 }
 
 ///Begins building a location search via an IP address.
-pub fn search_ip<'a>(query: &'a str) -> SearchBuilder<'a> {
+pub fn search_ip(query: String) -> SearchBuilder {
     SearchBuilder::new(PlaceQuery::IPAddress(query))
 }
 

--- a/src/place/fun.rs
+++ b/src/place/fun.rs
@@ -129,13 +129,13 @@ pub fn search_point(latitude: f64, longitude: f64) -> SearchBuilder {
 /// assert!(result.results.iter().any(|pl| pl.full_name == "British Columbia, Canada"));
 /// # }
 /// ```
-pub fn search_query(query: String) -> SearchBuilder {
-    SearchBuilder::new(PlaceQuery::Query(query))
+pub fn search_query(query: impl Into<CowStr>) -> SearchBuilder {
+    SearchBuilder::new(PlaceQuery::Query(query.into()))
 }
 
 ///Begins building a location search via an IP address.
-pub fn search_ip(query: String) -> SearchBuilder {
-    SearchBuilder::new(PlaceQuery::IPAddress(query))
+pub fn search_ip(query: impl Into<CowStr>) -> SearchBuilder {
+    SearchBuilder::new(PlaceQuery::IPAddress(query.into()))
 }
 
 ///From a URL given with the result of any `search_*` function, perform the same location search.

--- a/src/place/fun.rs
+++ b/src/place/fun.rs
@@ -2,8 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::future::Future;
-
 use crate::common::*;
 use crate::error::{Error::BadUrl, Result};
 use crate::{auth, links};
@@ -25,12 +23,10 @@ use super::*;
 /// assert!(result.full_name == "Dallas, TX");
 /// # }
 /// ```
-pub fn show(id: &str, token: &auth::Token) -> impl Future<Output = Result<Response<Place>>> {
+pub async fn show(id: &str, token: &auth::Token) -> Result<Response<Place>> {
     let url = format!("{}/{}.json", links::place::SHOW_STEM, id);
-
     let req = auth::get(&url, token, None);
-
-    make_parsed_future(req)
+    make_parsed_future(req).await
 }
 
 /// Begins building a reverse-geocode search with the given coordinate.

--- a/src/place/mod.rs
+++ b/src/place/mod.rs
@@ -310,7 +310,7 @@ impl<'a> SearchBuilder<'a> {
     }
 
     ///Finalize the search parameters and return the results collection.
-    pub fn call(&self, token: &auth::Token) -> FutureResponse<SearchResult> {
+    pub async fn call(&self, token: &auth::Token) -> Result<Response<SearchResult>, error::Error> {
         let mut params = match self.query {
             PlaceQuery::LatLon(lat, long) => ParamList::new()
                 .add_param("lat", lat.to_string())
@@ -330,8 +330,7 @@ impl<'a> SearchBuilder<'a> {
         }
 
         let req = auth::get(links::place::SEARCH, token, Some(&params));
-
-        make_parsed_future(req)
+        make_parsed_future(req).await
     }
 }
 

--- a/src/place/mod.rs
+++ b/src/place/mod.rs
@@ -211,8 +211,8 @@ impl GeocodeBuilder {
 
 enum PlaceQuery {
     LatLon(f64, f64),
-    Query(String),
-    IPAddress(String),
+    Query(CowStr),
+    IPAddress(CowStr),
 }
 
 ///Represents a location search query before it is sent.

--- a/src/place/mod.rs
+++ b/src/place/mod.rs
@@ -34,7 +34,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use serde_json;
 
 use crate::common::*;
-use crate::{auth, links};
+use crate::{auth, error, links};
 
 mod fun;
 
@@ -190,7 +190,7 @@ impl GeocodeBuilder {
     }
 
     ///Finalize the search parameters and return the results collection.
-    pub fn call(&self, token: &auth::Token) -> FutureResponse<SearchResult> {
+    pub async fn call(&self, token: &auth::Token) -> Result<Response<SearchResult>, error::Error> {
         let params = ParamList::new()
             .add_param("lat", self.coordinate.0.to_string())
             .add_param("long", self.coordinate.1.to_string())
@@ -205,8 +205,7 @@ impl GeocodeBuilder {
             );
 
         let req = auth::get(links::place::REVERSE_GEOCODE, token, Some(&params));
-
-        make_parsed_future(req)
+        make_parsed_future(req).await
     }
 }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -44,7 +44,6 @@
 //! [search-doc]: https://dev.twitter.com/rest/public/search
 //! [search-place]: https://dev.twitter.com/rest/public/search-by-place
 
-use std::borrow::Cow;
 use std::fmt;
 
 use serde::{Deserialize, Deserializer};

--- a/src/service.rs
+++ b/src/service.rs
@@ -17,6 +17,7 @@
 //! [config]: fn.config.html
 
 use std::collections::HashMap;
+use std::result::Result as StdResult;
 use std::str::FromStr;
 
 use serde::de::Error;
@@ -24,17 +25,20 @@ use serde::{Deserialize, Deserializer};
 use serde_json;
 
 use crate::common::*;
-use crate::error::Error::{InvalidResponse, MissingValue};
-use crate::{auth, entities, error, links};
+use crate::error::{
+    Error::{InvalidResponse, MissingValue},
+    Result,
+};
+use crate::{auth, entities, links};
 
 ///Returns a future that resolves to the current Twitter Terms of Service as plain text.
 ///
 ///While the official home of Twitter's TOS is <https://twitter.com/tos>, this allows you to obtain a
 ///plain-text copy of it to display in your application.
-pub fn terms(token: &auth::Token) -> FutureResponse<String> {
+pub async fn terms(token: &auth::Token) -> Result<Response<String>> {
     let req = auth::get(links::service::TERMS, token, None);
 
-    fn parse_terms(full_resp: String, headers: &Headers) -> Result<Response<String>, error::Error> {
+    fn parse_terms(full_resp: String, headers: &Headers) -> Result<Response<String>> {
         let ret: Response<serde_json::Value> = make_response(full_resp, headers)?;
 
         let tos = ret
@@ -46,20 +50,17 @@ pub fn terms(token: &auth::Token) -> FutureResponse<String> {
         Ok(Response::map(ret, |_| tos))
     }
 
-    make_future(req, parse_terms)
+    make_future(req, parse_terms).await
 }
 
 ///Returns a future that resolves to the current Twitter Privacy Policy as plain text.
 ///
 ///While the official home of Twitter's Privacy Policy is <https://twitter.com/privacy>, this allows
 ///you to obtain a plain-text copy of it to display in your application.
-pub fn privacy(token: &auth::Token) -> FutureResponse<String> {
+pub async fn privacy(token: &auth::Token) -> Result<Response<String>> {
     let req = auth::get(links::service::PRIVACY, token, None);
 
-    fn parse_policy(
-        full_resp: String,
-        headers: &Headers,
-    ) -> Result<Response<String>, error::Error> {
+    fn parse_policy(full_resp: String, headers: &Headers) -> Result<Response<String>> {
         let ret: Response<serde_json::Value> = make_response(full_resp, headers)?;
 
         let privacy = ret
@@ -71,7 +72,7 @@ pub fn privacy(token: &auth::Token) -> FutureResponse<String> {
         Ok(Response::map(ret, |_| privacy))
     }
 
-    make_future(req, parse_policy)
+    make_future(req, parse_policy).await
 }
 
 ///Returns a future that resolves to the current configuration from Twitter, including the maximum
@@ -84,10 +85,9 @@ pub fn privacy(token: &auth::Token) -> FutureResponse<String> {
 ///fields returned by this function mean.
 ///
 ///[`Configuration`]: struct.Configuration.html
-pub fn config(token: &auth::Token) -> FutureResponse<Configuration> {
+pub async fn config(token: &auth::Token) -> Result<Response<Configuration>> {
     let req = auth::get(links::service::CONFIG, token, None);
-
-    make_parsed_future(req)
+    make_parsed_future(req).await
 }
 
 ///Return the current rate-limit status for all available methods from the authenticated user.
@@ -97,20 +97,18 @@ pub fn config(token: &auth::Token) -> FutureResponse<Configuration> {
 ///documentation for [`RateLimitStatus`][] and its associated enums for more information.
 ///
 ///[`RateLimitStatus`]: struct.RateLimitStatus.html
-pub fn rate_limit_status(token: &auth::Token) -> FutureResponse<RateLimitStatus> {
+pub async fn rate_limit_status(token: &auth::Token) -> Result<Response<RateLimitStatus>> {
     let req = auth::get(links::service::RATE_LIMIT_STATUS, token, None);
-
-    make_parsed_future(req)
+    make_parsed_future(req).await
 }
 
 ///Like `rate_limit_status`, but returns the raw JSON without processing it. Only intended to
 ///return the full structure so that new methods can be added to `RateLimitStatus` and its
 ///associated enums.
 #[doc(hidden)]
-pub fn rate_limit_status_raw(token: &auth::Token) -> FutureResponse<serde_json::Value> {
+pub async fn rate_limit_status_raw(token: &auth::Token) -> Result<Response<serde_json::Value>> {
     let req = auth::get(links::service::RATE_LIMIT_STATUS, token, None);
-
-    make_parsed_future(req)
+    make_parsed_future(req).await
 }
 
 ///Represents a service configuration from Twitter.
@@ -196,7 +194,7 @@ pub struct RateLimitStatus {
 }
 
 impl<'de> Deserialize<'de> for RateLimitStatus {
-    fn deserialize<D>(ser: D) -> Result<Self, D::Error>
+    fn deserialize<D>(ser: D) -> StdResult<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
@@ -288,7 +286,7 @@ enum Method {
 impl FromStr for Method {
     type Err = ();
 
-    fn from_str(s: &str) -> Result<Self, ()> {
+    fn from_str(s: &str) -> StdResult<Self, ()> {
         match s {
             "/direct_messages" => Ok(Method::Direct(DirectMethod::Received)),
             "/direct_messages/sent" => Ok(Method::Direct(DirectMethod::Sent)),

--- a/src/service.rs
+++ b/src/service.rs
@@ -165,7 +165,7 @@ pub struct Configuration {
 /// # let status = egg_mode::service::rate_limit_status(&token).await.unwrap();
 /// use egg_mode::service::TweetMethod;
 /// println!("home_timeline calls remaining: {}",
-///          status.tweet[&TweetMethod::HomeTimeline].rate_limit_remaining);
+///          status.tweet[&TweetMethod::HomeTimeline].rate_limit_status.remaining);
 /// # }
 /// ```
 ///
@@ -199,6 +199,7 @@ impl<'de> Deserialize<'de> for RateLimitStatus {
         D: Deserializer<'de>,
     {
         use serde_json::from_value;
+        println!("HERE");
 
         let input = serde_json::Value::deserialize(ser)?;
 
@@ -220,6 +221,8 @@ impl<'de> Deserialize<'de> for RateLimitStatus {
                 .filter_map(|v| v.as_object())
                 .flat_map(|v| v.iter())
             {
+                println!("HERE2");
+                dbg!(&k, &v);
                 if let Ok(method) = k.parse::<Method>() {
                     match method {
                         Method::Direct(m) => {
@@ -254,13 +257,13 @@ impl<'de> Deserialize<'de> for RateLimitStatus {
         }
 
         Ok(RateLimitStatus {
-            direct: direct,
-            place: place,
-            search: search,
-            service: service,
-            tweet: tweet,
-            user: user,
-            list: list,
+            direct,
+            place,
+            search,
+            service,
+            tweet,
+            user,
+            list,
         })
     }
 }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -228,7 +228,7 @@ impl Stream for TwitterStream {
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
         if let Some(req) = self.request.take() {
-            self.response = Some(get_response(req)?);
+            self.response = Some(get_response(req));
         }
 
         if let Some(mut resp) = self.response.take() {

--- a/src/tweet/fun.rs
+++ b/src/tweet/fun.rs
@@ -180,7 +180,7 @@ pub fn user_timeline<T: Into<UserID>>(
 ) -> Timeline {
     let params = ParamList::new()
         .extended_tweets()
-        .add_name_param(&acct.into())
+        .add_name_param(acct.into())
         .add_param("exclude_replies", (!with_replies).to_string())
         .add_param("include_rts", with_rts.to_string());
 
@@ -201,7 +201,7 @@ pub fn retweets_of_me(token: &auth::Token) -> Timeline {
 pub fn liked_by<T: Into<UserID>>(acct: T, token: &auth::Token) -> Timeline {
     let params = ParamList::new()
         .extended_tweets()
-        .add_name_param(&acct.into());
+        .add_name_param(acct.into());
     Timeline::new(links::statuses::LIKES_OF, Some(params), token)
 }
 

--- a/src/tweet/fun.rs
+++ b/src/tweet/fun.rs
@@ -49,10 +49,7 @@ pub async fn retweets_of(id: u64, count: u32, token: &auth::Token) -> Result<Res
 ///set the page size. Calling `with_page_size` on the iterator returned by this function will not
 ///change the page size used by the network call. Setting `page_size` manually may result in an
 ///error from Twitter.
-pub fn retweeters_of(
-    id: u64,
-    token: &auth::Token,
-) -> cursor::CursorIter<'static, cursor::IDCursor> {
+pub fn retweeters_of(id: u64, token: &auth::Token) -> cursor::CursorIter<cursor::IDCursor> {
     let params = ParamList::new().add_param("id", id.to_string());
     cursor::CursorIter::new(links::statuses::RETWEETERS_OF, token, Some(params), None)
 }
@@ -149,7 +146,7 @@ pub async fn lookup_map<I: IntoIterator<Item = u64>>(
 ///This method has a default page size of 20 tweets, with a maximum of 200.
 ///
 ///Twitter will only return the most recent 800 tweets by navigating this method.
-pub fn home_timeline(token: &auth::Token) -> Timeline<'static> {
+pub fn home_timeline(token: &auth::Token) -> Timeline {
     Timeline::new(links::statuses::HOME_TIMELINE, None, token)
 }
 
@@ -159,7 +156,7 @@ pub fn home_timeline(token: &auth::Token) -> Timeline<'static> {
 ///This method has a default page size of 20 tweets, with a maximum of 200.
 ///
 ///Twitter will only return the most recent 800 tweets by navigating this method.
-pub fn mentions_timeline(token: &auth::Token) -> Timeline<'static> {
+pub fn mentions_timeline(token: &auth::Token) -> Timeline {
     Timeline::new(links::statuses::MENTIONS_TIMELINE, None, token)
 }
 
@@ -175,12 +172,12 @@ pub fn mentions_timeline(token: &auth::Token) -> Timeline<'static> {
 ///retweets.
 ///
 ///Twitter will only load the most recent 3,200 tweets with this method.
-pub fn user_timeline<'a, T: Into<UserID<'a>>>(
+pub fn user_timeline<T: Into<UserID>>(
     acct: T,
     with_replies: bool,
     with_rts: bool,
     token: &auth::Token,
-) -> Timeline<'a> {
+) -> Timeline {
     let params = ParamList::new()
         .extended_tweets()
         .add_name_param(&acct.into())
@@ -194,14 +191,14 @@ pub fn user_timeline<'a, T: Into<UserID<'a>>>(
 ///user that have been retweeted by others.
 ///
 ///This method has a default page size of 20 tweets, with a maximum of 100.
-pub fn retweets_of_me(token: &auth::Token) -> Timeline<'static> {
+pub fn retweets_of_me(token: &auth::Token) -> Timeline {
     Timeline::new(links::statuses::RETWEETS_OF_ME, None, token)
 }
 
 ///Make a `Timeline` struct for navigating the collection of tweets liked by the given user.
 ///
 ///This method has a default page size of 20 tweets, with a maximum of 200.
-pub fn liked_by<'a, T: Into<UserID<'a>>>(acct: T, token: &auth::Token) -> Timeline<'a> {
+pub fn liked_by<T: Into<UserID>>(acct: T, token: &auth::Token) -> Timeline {
     let params = ParamList::new()
         .extended_tweets()
         .add_name_param(&acct.into());

--- a/src/tweet/mod.rs
+++ b/src/tweet/mod.rs
@@ -419,7 +419,7 @@ pub struct ExtendedTweetEntities {
 /// let timeline = egg_mode::tweet::home_timeline(&token).with_page_size(10);
 ///
 /// let (timeline, feed) = timeline.start().await.unwrap();
-/// for tweet in &feed {
+/// for tweet in &*feed {
 ///     println!("<@{}> {}", tweet.user.as_ref().unwrap().screen_name, tweet.text);
 /// }
 /// # }
@@ -436,7 +436,7 @@ pub struct ExtendedTweetEntities {
 /// # let timeline = egg_mode::tweet::home_timeline(&token);
 /// # let (timeline, _) = timeline.start().await.unwrap();
 /// let (timeline, feed) = timeline.older(None).await.unwrap();
-/// for tweet in &feed {
+/// for tweet in &*feed {
 ///     println!("<@{}> {}", tweet.user.as_ref().unwrap().screen_name, tweet.text);
 /// }
 /// # }

--- a/src/tweet/mod.rs
+++ b/src/tweet/mod.rs
@@ -604,7 +604,7 @@ impl Timeline {
 #[must_use = "futures do nothing unless polled"]
 pub struct TimelineFuture {
     timeline: Option<Timeline>,
-    loader: Pin<Box<dyn Future<Output = Result<Response<Vec<Tweet>>>>>>,
+    loader: FutureResponse<Vec<Tweet>>,
 }
 
 impl Future for TimelineFuture {

--- a/src/tweet/mod.rs
+++ b/src/tweet/mod.rs
@@ -518,7 +518,7 @@ impl Timeline {
     ///ID to bound with.
     pub fn older(self, since_id: Option<u64>) -> TimelineFuture {
         let req = self.request(since_id, self.min_id.map(|id| id - 1));
-        let loader = make_parsed_future2(req);
+        let loader = Box::pin(make_parsed_future(req));
 
         TimelineFuture {
             timeline: Some(self),
@@ -530,7 +530,7 @@ impl Timeline {
     ///ID to bound with.
     pub fn newer(self, max_id: Option<u64>) -> TimelineFuture {
         let req = self.request(self.max_id, max_id);
-        let loader = make_parsed_future2(req);
+        let loader = Box::pin(make_parsed_future(req));
 
         TimelineFuture {
             timeline: Some(self),
@@ -604,7 +604,7 @@ impl Timeline {
 #[must_use = "futures do nothing unless polled"]
 pub struct TimelineFuture {
     timeline: Option<Timeline>,
-    loader: FutureResponse<Vec<Tweet>>,
+    loader: Pin<Box<dyn Future<Output = Result<Response<Vec<Tweet>>>>>>,
 }
 
 impl Future for TimelineFuture {

--- a/src/tweet/mod.rs
+++ b/src/tweet/mod.rs
@@ -518,7 +518,7 @@ impl<'a> Timeline<'a> {
     ///ID to bound with.
     pub fn older(self, since_id: Option<u64>) -> TimelineFuture<'a> {
         let req = self.request(since_id, self.min_id.map(|id| id - 1));
-        let loader = make_parsed_future(req);
+        let loader = make_parsed_future2(req);
 
         TimelineFuture {
             timeline: Some(self),
@@ -530,7 +530,7 @@ impl<'a> Timeline<'a> {
     ///ID to bound with.
     pub fn newer(self, max_id: Option<u64>) -> TimelineFuture<'a> {
         let req = self.request(self.max_id, max_id);
-        let loader = make_parsed_future(req);
+        let loader = make_parsed_future2(req);
 
         TimelineFuture {
             timeline: Some(self),

--- a/src/user/fun.rs
+++ b/src/user/fun.rs
@@ -28,7 +28,7 @@ use super::*;
 /// list.push(1234);
 /// list.push(2345);
 ///
-/// let users = egg_mode::user::lookup(&list, &token).await.unwrap();
+/// let users = egg_mode::user::lookup(list, &token).await.unwrap();
 /// # }
 /// ```
 ///
@@ -42,7 +42,7 @@ use super::*;
 /// list.push("rustlang");
 /// list.push("ThisWeekInRust");
 ///
-/// let users = egg_mode::user::lookup(&list, &token).await.unwrap();
+/// let users = egg_mode::user::lookup(list, &token).await.unwrap();
 /// # }
 /// ```
 ///
@@ -56,7 +56,7 @@ use super::*;
 /// list.push("rustlang".to_string());
 /// list.push("ThisWeekInRust".to_string());
 ///
-/// let users = egg_mode::user::lookup(&list, &token).await.unwrap();
+/// let users = egg_mode::user::lookup(list, &token).await.unwrap();
 /// # }
 /// ```
 ///
@@ -70,7 +70,7 @@ use super::*;
 /// list.push(1234.into());
 /// list.push("rustlang".into());
 ///
-/// let users = egg_mode::user::lookup(&list, &token).await.unwrap();
+/// let users = egg_mode::user::lookup(list, &token).await.unwrap();
 /// # }
 /// ```
 pub async fn lookup<T, I>(accts: I, token: &auth::Token) -> Result<Response<Vec<TwitterUser>>>

--- a/src/user/fun.rs
+++ b/src/user/fun.rs
@@ -6,8 +6,6 @@ use crate::common::*;
 use crate::error::Result;
 use crate::{auth, cursor, links};
 
-use std::borrow::Cow;
-
 use super::*;
 
 //---Groups of users---

--- a/src/user/fun.rs
+++ b/src/user/fun.rs
@@ -96,7 +96,7 @@ where
 pub async fn show<T: Into<UserID>>(acct: T, token: &auth::Token) -> Result<Response<TwitterUser>> {
     let params = ParamList::new()
         .extended_tweets()
-        .add_name_param(&acct.into());
+        .add_name_param(acct.into());
 
     let req = auth::get(links::users::SHOW, token, Some(&params));
 
@@ -174,7 +174,7 @@ pub fn friends_of<T: Into<UserID>>(
     acct: T,
     token: &auth::Token,
 ) -> cursor::CursorIter<cursor::UserCursor> {
-    let params = ParamList::new().add_name_param(&acct.into());
+    let params = ParamList::new().add_name_param(acct.into());
     cursor::CursorIter::new(links::users::FRIENDS_LIST, token, Some(params), Some(20))
 }
 
@@ -191,7 +191,7 @@ pub fn friends_ids<T: Into<UserID>>(
     acct: T,
     token: &auth::Token,
 ) -> cursor::CursorIter<cursor::IDCursor> {
-    let params = ParamList::new().add_name_param(&acct.into());
+    let params = ParamList::new().add_name_param(acct.into());
     cursor::CursorIter::new(links::users::FRIENDS_IDS, token, Some(params), Some(500))
 }
 
@@ -205,7 +205,7 @@ pub fn followers_of<T: Into<UserID>>(
 ) -> cursor::CursorIter<cursor::UserCursor> {
     let params = ParamList::new()
         .extended_tweets()
-        .add_name_param(&acct.into());
+        .add_name_param(acct.into());
     cursor::CursorIter::new(links::users::FOLLOWERS_LIST, token, Some(params), Some(20))
 }
 
@@ -221,7 +221,7 @@ pub fn followers_ids<T: Into<UserID>>(
     acct: T,
     token: &auth::Token,
 ) -> cursor::CursorIter<cursor::IDCursor> {
-    let params = ParamList::new().add_name_param(&acct.into());
+    let params = ParamList::new().add_name_param(acct.into());
     cursor::CursorIter::new(links::users::FOLLOWERS_IDS, token, Some(params), Some(500))
 }
 
@@ -304,7 +304,7 @@ pub async fn follow<T: Into<UserID>>(
 ) -> Result<Response<TwitterUser>> {
     let params = ParamList::new()
         .extended_tweets()
-        .add_name_param(&acct.into())
+        .add_name_param(acct.into())
         .add_param("follow", notifications.to_string());
     let req = auth::post(links::users::FOLLOW, token, Some(&params));
     make_parsed_future(req).await
@@ -322,7 +322,7 @@ pub async fn unfollow<T: Into<UserID>>(
 ) -> Result<Response<TwitterUser>> {
     let params = ParamList::new()
         .extended_tweets()
-        .add_name_param(&acct.into());
+        .add_name_param(acct.into());
     let req = auth::post(links::users::UNFOLLOW, token, Some(&params));
     make_parsed_future(req).await
 }
@@ -343,7 +343,7 @@ where
     T: Into<UserID>,
 {
     let params = ParamList::new()
-        .add_name_param(&acct.into())
+        .add_name_param(acct.into())
         .add_opt_param("device", notifications.map(|v| v.to_string()))
         .add_opt_param("retweets", retweets.map(|v| v.to_string()));
     let req = auth::post(links::users::FRIENDSHIP_UPDATE, token, Some(&params));
@@ -356,7 +356,7 @@ where
 pub async fn block<T: Into<UserID>>(acct: T, token: &auth::Token) -> Result<Response<TwitterUser>> {
     let params = ParamList::new()
         .extended_tweets()
-        .add_name_param(&acct.into());
+        .add_name_param(acct.into());
     let req = auth::post(links::users::BLOCK, token, Some(&params));
     make_parsed_future(req).await
 }
@@ -370,7 +370,7 @@ pub async fn report_spam<T: Into<UserID>>(
 ) -> Result<Response<TwitterUser>> {
     let params = ParamList::new()
         .extended_tweets()
-        .add_name_param(&acct.into());
+        .add_name_param(acct.into());
     let req = auth::post(links::users::REPORT_SPAM, token, Some(&params));
     make_parsed_future(req).await
 }
@@ -384,7 +384,7 @@ pub async fn unblock<T: Into<UserID>>(
 ) -> Result<Response<TwitterUser>> {
     let params = ParamList::new()
         .extended_tweets()
-        .add_name_param(&acct.into());
+        .add_name_param(acct.into());
     let req = auth::post(links::users::UNBLOCK, token, Some(&params));
     make_parsed_future(req).await
 }
@@ -395,7 +395,7 @@ pub async fn unblock<T: Into<UserID>>(
 pub async fn mute<T: Into<UserID>>(acct: T, token: &auth::Token) -> Result<Response<TwitterUser>> {
     let params = ParamList::new()
         .extended_tweets()
-        .add_name_param(&acct.into());
+        .add_name_param(acct.into());
     let req = auth::post(links::users::MUTE, token, Some(&params));
     make_parsed_future(req).await
 }
@@ -409,7 +409,7 @@ pub async fn unmute<T: Into<UserID>>(
 ) -> Result<Response<TwitterUser>> {
     let params = ParamList::new()
         .extended_tweets()
-        .add_name_param(&acct.into());
+        .add_name_param(acct.into());
     let req = auth::post(links::users::UNMUTE, token, Some(&params));
     make_parsed_future(req).await
 }

--- a/src/user/fun.rs
+++ b/src/user/fun.rs
@@ -75,9 +75,9 @@ use super::*;
 /// let users = egg_mode::user::lookup(&list, &token).await.unwrap();
 /// # }
 /// ```
-pub async fn lookup<'a, T, I>(accts: I, token: &auth::Token) -> Result<Response<Vec<TwitterUser>>>
+pub async fn lookup<T, I>(accts: I, token: &auth::Token) -> Result<Response<Vec<TwitterUser>>>
 where
-    T: Into<UserID<'a>>,
+    T: Into<UserID>,
     I: IntoIterator<Item = T>,
 {
     let (id_param, name_param) = multiple_names_param(accts);
@@ -93,10 +93,7 @@ where
 }
 
 /// Lookup user information for a single user.
-pub async fn show<'a, T: Into<UserID<'a>>>(
-    acct: T,
-    token: &auth::Token,
-) -> Result<Response<TwitterUser>> {
+pub async fn show<T: Into<UserID>>(acct: T, token: &auth::Token) -> Result<Response<TwitterUser>> {
     let params = ParamList::new()
         .extended_tweets()
         .add_name_param(&acct.into());
@@ -116,14 +113,10 @@ pub async fn friends_no_retweets(token: &auth::Token) -> Result<Response<Vec<u64
 }
 
 /// Lookup relationship settings between two arbitrary users.
-pub async fn relation<'a, F, T>(
-    from: F,
-    to: T,
-    token: &auth::Token,
-) -> Result<Response<Relationship>>
+pub async fn relation<F, T>(from: F, to: T, token: &auth::Token) -> Result<Response<Relationship>>
 where
-    F: Into<UserID<'a>>,
-    T: Into<UserID<'a>>,
+    F: Into<UserID>,
+    T: Into<UserID>,
 {
     let mut params = match from.into() {
         UserID::ID(id) => ParamList::new().add_param("source_id", id.to_string()),
@@ -140,12 +133,12 @@ where
 }
 
 /// Lookup the relations between the authenticated user and the given accounts.
-pub async fn relation_lookup<'a, T, I>(
+pub async fn relation_lookup<T, I>(
     accts: I,
     token: &auth::Token,
 ) -> Result<Response<Vec<RelationLookup>>>
 where
-    T: Into<UserID<'a>>,
+    T: Into<UserID>,
     I: IntoIterator<Item = T>,
 {
     let (id_param, name_param) = multiple_names_param(accts);
@@ -169,7 +162,7 @@ where
 /// page for details.
 ///
 /// [`UserSearch`]: struct.UserSearch.html
-pub fn search<'a, S: Into<Cow<'a, str>>>(query: S, token: &auth::Token) -> UserSearch<'a> {
+pub fn search<S: Into<CowStr>>(query: S, token: &auth::Token) -> UserSearch {
     UserSearch::new(query, token)
 }
 
@@ -177,10 +170,10 @@ pub fn search<'a, S: Into<Cow<'a, str>>>(query: S, token: &auth::Token) -> UserS
 ///
 /// This function returns a stream over the `TwitterUser` objects returned by Twitter. This
 /// method defaults to returning 20 users in a single network call; the maximum is 200.
-pub fn friends_of<'a, T: Into<UserID<'a>>>(
+pub fn friends_of<T: Into<UserID>>(
     acct: T,
     token: &auth::Token,
-) -> cursor::CursorIter<'a, cursor::UserCursor> {
+) -> cursor::CursorIter<cursor::UserCursor> {
     let params = ParamList::new().add_name_param(&acct.into());
     cursor::CursorIter::new(links::users::FRIENDS_LIST, token, Some(params), Some(20))
 }
@@ -194,10 +187,10 @@ pub fn friends_of<'a, T: Into<UserID<'a>>>(
 /// Choosing only to load the user IDs instead of the full user information results in a call that
 /// can return more accounts per-page, which can be useful if you anticipate having to page through
 /// several results and don't need all the user information.
-pub fn friends_ids<'a, T: Into<UserID<'a>>>(
+pub fn friends_ids<T: Into<UserID>>(
     acct: T,
     token: &auth::Token,
-) -> cursor::CursorIter<'a, cursor::IDCursor> {
+) -> cursor::CursorIter<cursor::IDCursor> {
     let params = ParamList::new().add_name_param(&acct.into());
     cursor::CursorIter::new(links::users::FRIENDS_IDS, token, Some(params), Some(500))
 }
@@ -206,10 +199,10 @@ pub fn friends_ids<'a, T: Into<UserID<'a>>>(
 ///
 /// This function returns a stream over the `TwitterUser` objects returned by Twitter. This
 /// method defaults to returning 20 users in a single network call; the maximum is 200.
-pub fn followers_of<'a, T: Into<UserID<'a>>>(
+pub fn followers_of<T: Into<UserID>>(
     acct: T,
     token: &auth::Token,
-) -> cursor::CursorIter<'a, cursor::UserCursor> {
+) -> cursor::CursorIter<cursor::UserCursor> {
     let params = ParamList::new()
         .extended_tweets()
         .add_name_param(&acct.into());
@@ -224,10 +217,10 @@ pub fn followers_of<'a, T: Into<UserID<'a>>>(
 /// Choosing only to load the user IDs instead of the full user information results in a call that
 /// can return more accounts per-page, which can be useful if you anticipate having to page through
 /// several results and don't need all the user information.
-pub fn followers_ids<'a, T: Into<UserID<'a>>>(
+pub fn followers_ids<T: Into<UserID>>(
     acct: T,
     token: &auth::Token,
-) -> cursor::CursorIter<'a, cursor::IDCursor> {
+) -> cursor::CursorIter<cursor::IDCursor> {
     let params = ParamList::new().add_name_param(&acct.into());
     cursor::CursorIter::new(links::users::FOLLOWERS_IDS, token, Some(params), Some(500))
 }
@@ -238,7 +231,7 @@ pub fn followers_ids<'a, T: Into<UserID<'a>>>(
 /// the page size. Calling `with_page_size` on a stream returned by this function will not
 /// change the page size used by the network call. Setting `page_size` manually may result in an
 /// error from Twitter.
-pub fn blocks(token: &auth::Token) -> cursor::CursorIter<'static, cursor::UserCursor> {
+pub fn blocks(token: &auth::Token) -> cursor::CursorIter<cursor::UserCursor> {
     cursor::CursorIter::new(links::users::BLOCKS_LIST, token, None, None)
 }
 
@@ -253,7 +246,7 @@ pub fn blocks(token: &auth::Token) -> cursor::CursorIter<'static, cursor::UserCu
 /// the page size. Calling `with_page_size` on a stream returned by this function will not
 /// change the page size used by the network call. Setting `page_size` manually may result in an
 /// error from Twitter.
-pub fn blocks_ids(token: &auth::Token) -> cursor::CursorIter<'static, cursor::IDCursor> {
+pub fn blocks_ids(token: &auth::Token) -> cursor::CursorIter<cursor::IDCursor> {
     cursor::CursorIter::new(links::users::BLOCKS_IDS, token, None, None)
 }
 
@@ -263,7 +256,7 @@ pub fn blocks_ids(token: &auth::Token) -> cursor::CursorIter<'static, cursor::ID
 /// the page size. Calling `with_page_size` on a stream returned by this function will not
 /// change the page size used by the network call. Setting `page_size` manually may result in an
 /// error from Twitter.
-pub fn mutes(token: &auth::Token) -> cursor::CursorIter<'static, cursor::UserCursor> {
+pub fn mutes(token: &auth::Token) -> cursor::CursorIter<cursor::UserCursor> {
     cursor::CursorIter::new(links::users::MUTES_LIST, token, None, None)
 }
 
@@ -277,19 +270,19 @@ pub fn mutes(token: &auth::Token) -> cursor::CursorIter<'static, cursor::UserCur
 /// the page size. Calling `with_page_size` on a stream returned by this function will not
 /// change the page size used by the network call. Setting `page_size` manually may result in an
 /// error from Twitter.
-pub fn mutes_ids(token: &auth::Token) -> cursor::CursorIter<'static, cursor::IDCursor> {
+pub fn mutes_ids(token: &auth::Token) -> cursor::CursorIter<cursor::IDCursor> {
     cursor::CursorIter::new(links::users::MUTES_IDS, token, None, None)
 }
 
 /// Lookup the user IDs who have pending requests to follow the authenticated protected user.
 ///
 /// If the authenticated user is not a protected account, this will return an empty collection.
-pub fn incoming_requests(token: &auth::Token) -> cursor::CursorIter<'static, cursor::IDCursor> {
+pub fn incoming_requests(token: &auth::Token) -> cursor::CursorIter<cursor::IDCursor> {
     cursor::CursorIter::new(links::users::FRIENDSHIPS_INCOMING, token, None, None)
 }
 
 /// Lookup the user IDs with which the authenticating user has a pending follow request.
-pub fn outgoing_requests(token: &auth::Token) -> cursor::CursorIter<'static, cursor::IDCursor> {
+pub fn outgoing_requests(token: &auth::Token) -> cursor::CursorIter<cursor::IDCursor> {
     cursor::CursorIter::new(links::users::FRIENDSHIPS_OUTGOING, token, None, None)
 }
 
@@ -304,7 +297,7 @@ pub fn outgoing_requests(token: &auth::Token) -> cursor::CursorIter<'static, cur
 ///
 /// Calling this with an account the user already follows may return an error, or ("for performance
 /// reasons") may return success without changing any account settings.
-pub async fn follow<'a, T: Into<UserID<'a>>>(
+pub async fn follow<T: Into<UserID>>(
     acct: T,
     notifications: bool,
     token: &auth::Token,
@@ -323,7 +316,7 @@ pub async fn follow<'a, T: Into<UserID<'a>>>(
 ///
 /// Calling this with an account the user doesn't follow will return success, even though it doesn't
 /// change any settings.
-pub async fn unfollow<'a, T: Into<UserID<'a>>>(
+pub async fn unfollow<T: Into<UserID>>(
     acct: T,
     token: &auth::Token,
 ) -> Result<Response<TwitterUser>> {
@@ -340,14 +333,14 @@ pub async fn unfollow<'a, T: Into<UserID<'a>>>(
 /// to follow that user. It will return an error if you pass `Some(true)` for `notifications` or
 /// `Some(false)` for `retweets`. Any other combination of arguments will return a `Relationship` as
 /// if you had called `relation` between the authenticated user and the given user.
-pub async fn update_follow<'a, T>(
+pub async fn update_follow<T>(
     acct: T,
     notifications: Option<bool>,
     retweets: Option<bool>,
     token: &auth::Token,
 ) -> Result<Response<Relationship>>
 where
-    T: Into<UserID<'a>>,
+    T: Into<UserID>,
 {
     let params = ParamList::new()
         .add_name_param(&acct.into())
@@ -360,10 +353,7 @@ where
 /// Block the given account with the authenticated user.
 ///
 /// Upon success, the future returned by this function yields the given user.
-pub async fn block<'a, T: Into<UserID<'a>>>(
-    acct: T,
-    token: &auth::Token,
-) -> Result<Response<TwitterUser>> {
+pub async fn block<T: Into<UserID>>(acct: T, token: &auth::Token) -> Result<Response<TwitterUser>> {
     let params = ParamList::new()
         .extended_tweets()
         .add_name_param(&acct.into());
@@ -374,7 +364,7 @@ pub async fn block<'a, T: Into<UserID<'a>>>(
 /// Block the given account and report it for spam, with the authenticated user.
 ///
 /// Upon success, the future returned by this function yields the given user.
-pub async fn report_spam<'a, T: Into<UserID<'a>>>(
+pub async fn report_spam<T: Into<UserID>>(
     acct: T,
     token: &auth::Token,
 ) -> Result<Response<TwitterUser>> {
@@ -388,7 +378,7 @@ pub async fn report_spam<'a, T: Into<UserID<'a>>>(
 /// Unblock the given user with the authenticated user.
 ///
 /// Upon success, the future returned by this function yields the given user.
-pub async fn unblock<'a, T: Into<UserID<'a>>>(
+pub async fn unblock<T: Into<UserID>>(
     acct: T,
     token: &auth::Token,
 ) -> Result<Response<TwitterUser>> {
@@ -402,10 +392,7 @@ pub async fn unblock<'a, T: Into<UserID<'a>>>(
 /// Mute the given user with the authenticated user.
 ///
 /// Upon success, the future returned by this function yields the given user.
-pub async fn mute<'a, T: Into<UserID<'a>>>(
-    acct: T,
-    token: &auth::Token,
-) -> Result<Response<TwitterUser>> {
+pub async fn mute<T: Into<UserID>>(acct: T, token: &auth::Token) -> Result<Response<TwitterUser>> {
     let params = ParamList::new()
         .extended_tweets()
         .add_name_param(&acct.into());
@@ -416,7 +403,7 @@ pub async fn mute<'a, T: Into<UserID<'a>>>(
 /// Unmute the given user with the authenticated user.
 ///
 /// Upon success, the future returned by this function yields the given user.
-pub async fn unmute<'a, T: Into<UserID<'a>>>(
+pub async fn unmute<T: Into<UserID>>(
     acct: T,
     token: &auth::Token,
 ) -> Result<Response<TwitterUser>> {

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -55,7 +55,6 @@
 //! - `mutes`/`mutes_ids`
 //! - `incoming_requests`/`outgoing_requests`
 
-use std::borrow::Cow;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -546,8 +546,7 @@ impl<'a> UserSearch<'a> {
             .add_param("count", self.page_size.to_string());
 
         let req = auth::get(links::users::SEARCH, &self.token, Some(&params));
-
-        make_parsed_future(req)
+        make_parsed_future2(req)
     }
 
     /// Returns a new UserSearch with the given query and tokens, with the default page size of 10.

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -420,7 +420,7 @@ pub struct UserEntityDetail {
 ///
 /// // Because Streams don't have a FromIterator adaptor, we load all the responses first, then
 /// // collect them into the final Vec
-/// let names: Result<Response<Vec<TwitterUser>>, Error> =
+/// let names: Result<Vec<TwitterUser>, Error> =
 ///     egg_mode::user::search("rustlang", &token)
 ///         .take(10)
 ///         .try_collect::<Vec<_>>()

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -479,8 +479,7 @@ pub struct UserSearch {
     pub page_num: i32,
     /// The number of user records per page of results. Defaults to 10, maximum of 20.
     pub page_size: i32,
-    current_loader:
-        Option<Pin<Box<dyn Future<Output = error::Result<Response<Vec<TwitterUser>>>>>>>,
+    current_loader: Option<FutureResponse<Vec<TwitterUser>>>,
     current_results: Option<VecIter<TwitterUser>>,
 }
 


### PR DESCRIPTION
Big grab bag of changes.

* Remove almost all the methods around `Response` / `ResponseIter`. I didn't think these were pulling their weight given the extra complexity.
* Use `thiserror` to generate the `Error` type implementation. This involved removing the hard-deprecated `fn description` method.
* Remove all the lifetimes inside various structs (e.g. `UserID`, `ParamList` &c). The extra complexity of handling these lifetimes was making refactoring very tricky, and the performance gain is minimal
* pull the rate limit data into it's own `RateLimitStatus` type with the help of `#[serde(flatten)]`
* made `FutureResult` just an alias for `Pin<Box<dyn Future<Output=Result<T>>>>`. First step to removing as many `Future` and `Stream` implementations as possible and just using `async fn` instead
* lots of other small changes